### PR TITLE
making the examples standalond

### DIFF
--- a/examples/multiModel/README.md
+++ b/examples/multiModel/README.md
@@ -1,0 +1,30 @@
+# Multi Model Example
+
+This example demonstrates how one router supports multiple models. 
+
+## Learning ESP
+
+- [Documentation](https://github.com/esp/esp-js)
+
+### Get help from other users:
+
+- [esp/chat on Gitter Chat](https://gitter.im/esp/chat)
+- [Questions tagged esp-js on StackOverflow](http://stackoverflow.com/questions/tagged/esp-js)
+- [GitHub Issues](https://github.com/esp/esp-js/issues)
+
+*Let us [know](https://github.com/esp/esp-js/issues) if you discover anything worth sharing!*
+
+
+## Running
+
+You must have [npm](https://www.npmjs.org/) installed on your computer.
+From the same directory as this read me run these commands from the command line:
+
+`npm install`
+
+This will install all dependencies.
+
+`npm start`
+
+This will call babel to transpile app.js and run it via node. 
+

--- a/examples/multiModel/app.js
+++ b/examples/multiModel/app.js
@@ -16,7 +16,7 @@
  */
  // notice_end
 
-import esp from '../../dist/esp.js';
+import esp from 'esp-js';
 
 class ProductionLine {
     constructor() {

--- a/examples/multiModel/package.json
+++ b/examples/multiModel/package.json
@@ -1,5 +1,11 @@
 {
   "scripts": {
-    "start": "../../node_modules/.bin/babel-node app.js"
+    "start": "./node_modules/.bin/babel-node app.js"
+  },
+  "dependencies": {
+    "esp-js": "0.0.11"
+  },
+  "devDependencies": {
+    "babel": "5.8.9"
   }
 }

--- a/examples/observableApi/README.md
+++ b/examples/observableApi/README.md
@@ -1,0 +1,30 @@
+# Observable Api Example
+
+This example demonstrates the observable nature of the `Router's` api. 
+
+## Learning ESP
+
+- [Documentation](https://github.com/esp/esp-js)
+
+### Get help from other users:
+
+- [esp/chat on Gitter Chat](https://gitter.im/esp/chat)
+- [Questions tagged esp-js on StackOverflow](http://stackoverflow.com/questions/tagged/esp-js)
+- [GitHub Issues](https://github.com/esp/esp-js/issues)
+
+*Let us [know](https://github.com/esp/esp-js/issues) if you discover anything worth sharing!*
+
+
+## Running
+
+You must have [npm](https://www.npmjs.org/) installed on your computer.
+From the same directory as this read me run these commands from the command line:
+
+`npm install`
+
+This will install all dependencies.
+
+`npm start`
+
+This will call babel to transpile app.js and run it via node. 
+

--- a/examples/observableApi/app.js
+++ b/examples/observableApi/app.js
@@ -16,7 +16,7 @@
  */
  // notice_end
 
-import esp from '../../dist/esp.js';
+import esp from 'esp-js';
 
 // note there are several concerns here that would exist in different areas of your architecture
 // then are all together to demo the concepts.

--- a/examples/observableApi/package.json
+++ b/examples/observableApi/package.json
@@ -1,5 +1,11 @@
 {
   "scripts": {
-    "start": "../../node_modules/.bin/babel-node app.js"
+    "start": "./node_modules/.bin/babel-node app.js"
+  },
+  "dependencies": {
+    "esp-js": "0.0.11"
+  },
+  "devDependencies": {
+    "babel": "5.8.9"
   }
 }

--- a/examples/readme/README.md
+++ b/examples/readme/README.md
@@ -1,0 +1,33 @@
+# ReadMe.md Examples
+
+This example contains the code that is used in main esp-js ReadMe.md. 
+
+
+## Learning ESP
+
+- [Documentation](https://github.com/esp/esp-js)
+
+### Get help from other users:
+
+- [esp/chat on Gitter Chat](https://gitter.im/esp/chat)
+- [Questions tagged esp-js on StackOverflow](http://stackoverflow.com/questions/tagged/esp-js)
+- [GitHub Issues](https://github.com/esp/esp-js/issues)
+
+*Let us [know](https://github.com/esp/esp-js/issues) if you discover anything worth sharing!*
+
+
+## Running
+
+You must have [npm](https://www.npmjs.org/) installed on your computer.
+From the same directory as this read me run these commands from the command line:
+
+`npm install`
+
+This will install all dependencies.
+
+`npm start`
+
+This will call babel to transpile app.js and run it via node. 
+
+There are several examples in the readme, you'll get an option to select which example to run.
+

--- a/examples/readme/app.js
+++ b/examples/readme/app.js
@@ -16,7 +16,8 @@
  */
  // notice_end
 
-import esp from '../../dist/esp.js';
+import esp from 'esp-js';
+import prompt from 'prompt';
 
 ////////////////////////////////////////////////////////////// basic usage example //////////////////////////////////////////////////////////////
 var runBasicExample =  () => {
@@ -640,14 +641,46 @@ var runModelRouter = () => {
     modelRouter.publishEvent('fooEvent', { theFoo: 1});
     modelRouter.publishEvent('fooEvent', { theFoo: 2});
 };
-// uncomment out the example you want to run, you can uncomment them all but their results would overlap as they do things async.
 
-// runBasicExample();
-// runEventWorkflowExample();
-// runModelObserveExample();
-// runObserveApiBasicExample();
-// runErrorFlowsExample();
-// runAsyncWorkExample();
-// runWorkItemExample();
-// runModelLockUnlock();
-runModelRouter();
+///////////////////////// example bootstrap code /////////////////
+// Simply calls one of the functions above via the prompt
+//////////////////////////////////////////////////////////////////
+
+var examples = {
+    "1" : { description : "Basic Example", action : runBasicExample },
+    "2" : { description : "Event Workflow Example", action : runEventWorkflowExample },
+    "3" : { description : "Model Observe Example", action : runModelObserveExample },
+    "4" : { description : "Observable Api Basic Example", action : runObserveApiBasicExample },
+    "5" : { description : "Async Work Example", action : runAsyncWorkExample },
+    "6" : { description : "Work Item Example", action : runWorkItemExample },
+    "7" : { description : "Model Lock/Unlock", action : runModelLockUnlock },
+};
+
+console.log('Which sample do you want to run (enter a number)?');
+for (let exampleKey in examples) {
+    if (examples.hasOwnProperty(exampleKey)) {
+        console.log('%s - %s', exampleKey, examples[exampleKey].description);
+    }
+}
+
+var properties = [
+    {
+        name: 'sampleNumber',
+        validator: /^[1-7]$/,
+        warning: 'Sample number must be a number between 1-7 inclusive'
+    }
+];
+
+prompt.start();
+
+prompt.get(properties, function (err, result) {
+    if (err) { return onErr(err); }
+    var example = examples[result.sampleNumber];
+    console.log('Running sample \'%s\'', example.description);
+    examples[result.sampleNumber].action();
+});
+
+function onErr(err) {
+    console.log(err);
+    return 1;
+}

--- a/examples/readme/package.json
+++ b/examples/readme/package.json
@@ -1,5 +1,12 @@
 {
   "scripts": {
-    "start": "../../node_modules/.bin/babel-node app.js"
+    "start": "./node_modules/.bin/babel-node app.js"
+  },
+  "dependencies": {
+    "esp-js": "0.0.11",
+    "prompt": "^0.2.14"
+  },
+  "devDependencies": {
+    "babel": "5.8.9"
   }
 }

--- a/examples/smallEndToEnd/README.md
+++ b/examples/smallEndToEnd/README.md
@@ -1,0 +1,30 @@
+# Small End to End Example
+
+This example contains a small 'model side' end-to-end example. 
+
+
+## Learning ESP
+
+- [Documentation](https://github.com/esp/esp-js)
+
+### Get help from other users:
+
+- [esp/chat on Gitter Chat](https://gitter.im/esp/chat)
+- [Questions tagged esp-js on StackOverflow](http://stackoverflow.com/questions/tagged/esp-js)
+- [GitHub Issues](https://github.com/esp/esp-js/issues)
+
+*Let us [know](https://github.com/esp/esp-js/issues) if you discover anything worth sharing!*
+
+
+## Running
+
+You must have [npm](https://www.npmjs.org/) installed on your computer.
+From the same directory as this read me run these commands from the command line:
+
+`npm install`
+
+This will install all dependencies.
+
+`npm start`
+
+This will call babel to transpile app.js and run it via node. 

--- a/examples/smallEndToEnd/app.js
+++ b/examples/smallEndToEnd/app.js
@@ -16,7 +16,7 @@
  */
  // notice_end
 
-import esp from '../../dist/esp.js';
+import esp from 'esp-js';
 import ModelBootstrapper from './model/ModelBootstrapper';
 import MainController from './controllers/MainController';
 

--- a/examples/smallEndToEnd/controllers/MainController.js
+++ b/examples/smallEndToEnd/controllers/MainController.js
@@ -16,7 +16,7 @@
  */
  // notice_end
 
-import esp from '../../../dist/esp.js';
+import esp from 'esp-js';
 
 class MainController extends esp.model.DisposableBase {
     constructor(router) {

--- a/examples/smallEndToEnd/model/eventProcessors/NotionalEventProcessor.js
+++ b/examples/smallEndToEnd/model/eventProcessors/NotionalEventProcessor.js
@@ -16,7 +16,7 @@
  */
  // notice_end
 
-import esp from '../../../../dist/esp.js';
+import esp from 'esp-js';
 
 class NotionalEventProcessor extends esp.model.DisposableBase {
     constructor(router) {

--- a/examples/smallEndToEnd/model/eventProcessors/StaticDataEventProcessor.js
+++ b/examples/smallEndToEnd/model/eventProcessors/StaticDataEventProcessor.js
@@ -16,7 +16,7 @@
  */
  // notice_end
 
-import esp from '../../../../dist/esp.js';
+import esp from 'esp-js';
 
 class StaticDataEventProcessor extends esp.model.DisposableBase {
     constructor(router) {

--- a/examples/smallEndToEnd/package.json
+++ b/examples/smallEndToEnd/package.json
@@ -1,5 +1,11 @@
 {
   "scripts": {
-    "start": "../../node_modules/.bin/babel-node app.js"
+    "start": "./node_modules/.bin/babel-node app.js"
+  },
+  "dependencies": {
+    "esp-js": "0.0.11"
+  },
+  "devDependencies": {
+    "babel": "5.8.9"
   }
 }


### PR DESCRIPTION
Properly fixed #18 

Examples are now standalone:
* reference esp-js from npm
* reference babel from npm
* have readme files

Additionally examples/readme have a command prompt option to allow the users to select which part of the read me they want to run. Before you had to comment out code and select the option you want.