### PR TITLE
fix definitions

### DIFF
--- a/esp.d.ts
+++ b/esp.d.ts
@@ -93,7 +93,6 @@ export interface ModelObservable<T> {
 }
 
 export class ModelChangedEvent<T> {
-    get modelId() : string;
-
-    get model() : T;
+    modelId: string;
+    model: T;
 }


### PR DESCRIPTION
An accessor function should be declared as a property in .d.ts