### PR TITLE
Observable.subscribeOn / Observable.observeOn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esp-js",
-  "version": "0.7.12",
+  "version": "0.8.0",
   "description": "Evented State Processor (ESP) adds specific processing workflow around changes to a model's state",
   "keywords": [
     "state processor",

--- a/src/index.js
+++ b/src/index.js
@@ -26,16 +26,17 @@
 // let eventContext = new EventContext()
 
 export { ObservationStage, Router, SingleModelRouter, EventContext, ModelChangedEvent } from './router';
-export { CompositeDisposable, DictionaryDisposable, DisposableBase } from './system/disposables';
+export { CompositeDisposable, DictionaryDisposable, DisposableBase, DisposableWrapper } from './system/disposables';
 export { observeEvent, observeModelChangedEvent } from './decorators/observeEvent';
 export { logging } from './system';
 export { Observable } from './reactive';
 
 import { ObservationStage, Router, SingleModelRouter, EventContext, ModelChangedEvent } from './router';
-import { CompositeDisposable, DictionaryDisposable, DisposableBase } from './system/disposables';
+import { CompositeDisposable, DictionaryDisposable, DisposableBase, DisposableWrapper } from './system/disposables';
 import { observeEvent, observeModelChangedEvent } from './decorators/observeEvent';
 import { logging as logging } from './system';
-import { Observable } from './reactive';
+import { Observable, Subject } from './reactive';
+
 export default {
     ObservationStage,
     Router,
@@ -48,5 +49,7 @@ export default {
     EventContext,
     CompositeDisposable,
     DictionaryDisposable,
-    Observable
+    DisposableWrapper,
+    Observable,
+    Subject
 }

--- a/src/reactive/Observable.js
+++ b/src/reactive/Observable.js
@@ -17,13 +17,15 @@
  // notice_end
 
 import { Guard } from '../system';
+import { DisposableWrapper } from '../system/disposables';
 import Observer from './Observer';
 
 export default class Observable {
     static create(onObserve) {
         Guard.lengthIs(arguments, 1, "Incorrect argument count on Observable, expect 1 onObserve function");
         var observe =  observer => {
-            return onObserve(observer);
+            let disposable = onObserve(observer);
+            return new DisposableWrapper(disposable);
         };
         return new Observable(observe);
     }

--- a/src/reactive/extMethods/observeOn.js
+++ b/src/reactive/extMethods/observeOn.js
@@ -1,0 +1,46 @@
+// notice_start
+/*
+ * Copyright 2015 Dev Shop Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// notice_end
+
+import Observable from '../Observable';
+import { Guard } from '../../system';
+
+Observable.prototype.observeOn = function(router, modelId) {
+    Guard.isDefined(router, "router must be defined");
+    Guard.isString(modelId, "modelId must be a string");
+    var source = this;
+    var hasCompleted = false;
+    var observe =  observer => {
+        return source.observe(
+            (arg1, arg2, arg3) => {
+                if(hasCompleted ) {
+                    return;
+                }
+                router.runAction(modelId, () => {
+                    observer.onNext(arg1, arg2, arg3);
+                });
+            },
+            () => {
+                hasCompleted = true;
+                router.runAction(modelId, () => {
+                    observer.onCompleted();
+                });
+            }
+        );
+    };
+    return new Observable(observe);
+};

--- a/src/reactive/extMethods/subscribeOn.js
+++ b/src/reactive/extMethods/subscribeOn.js
@@ -1,0 +1,45 @@
+// notice_start
+/*
+ * Copyright 2015 Dev Shop Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// notice_end
+
+import Observable from '../Observable';
+import { Guard } from '../../system';
+
+Observable.prototype.subscribeOn = function(router, modelId) {
+    Guard.isDefined(router, "router must be defined");
+    Guard.isString(modelId, "modelId must be a string");
+    var source = this;
+    var observe =  observer => {
+        let disposable = {
+            subscription:null,
+            isDisposed:false,
+            dispose() {
+                this.isDisposed = true;
+                if(this.subscription) {
+                    this.subscription.dispose();
+                }
+            }
+        };
+        router.runAction(modelId, () => {
+            if(!disposable.isDisposed) {
+                disposable.subscription = source.observe(observer);
+            }
+        });
+        return disposable;
+    };
+    return new Observable(observe);
+};

--- a/src/reactive/index.js
+++ b/src/reactive/index.js
@@ -22,6 +22,8 @@ import './extMethods/asObservable';
 import './extMethods/take';
 import './extMethods/do';
 import './extMethods/map';
+import './extMethods/observeOn';
+import './extMethods/subscribeOn';
 
 export { default as Observable } from './Observable';
 export { default as Observer } from './Observer';

--- a/src/system/Guard.js
+++ b/src/system/Guard.js
@@ -20,7 +20,7 @@ import * as utils from './utils';
 
 export default class Guard {
     static isDefined(value, message) {
-        if (typeof value === 'undefined') {
+        if (typeof value === 'undefined' || value === null) {
             doThrow(message);
         }
     }

--- a/tests/indexTests.js
+++ b/tests/indexTests.js
@@ -13,7 +13,8 @@ import {
     observeEvent,
     observeModelChangedEvent,
     model,
-    logging
+    logging,
+    DisposableWrapper
 } from '../src';
 
 describe('index exports', () => {
@@ -50,6 +51,11 @@ describe('index exports', () => {
     it('should export DisposableBase', () => {
         expect(esp.DisposableBase).toBeDefined();
         expect(DisposableBase).toBeDefined();
+    });
+
+    it('should export DisposableWrapper', () => {
+        expect(esp.DisposableWrapper).toBeDefined();
+        expect(DisposableWrapper).toBeDefined();
     });
 
     it('should export Observable', () => {

--- a/tests/reactive/observeOnTests.js
+++ b/tests/reactive/observeOnTests.js
@@ -1,0 +1,114 @@
+// notice_start
+/*
+ * Copyright 2015 Dev Shop Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// notice_end
+
+import esp from '../../src';
+import TestModel from './testModel';
+
+describe('.observeOn', () => {
+    var _router;
+    var _testModel1;
+    var _testModel2;
+    var _workflowActions;
+
+    beforeEach(() => {
+        _router = new esp.Router();
+        _workflowActions = [];
+        _testModel1 = new TestModel('m1', _router, _workflowActions);
+        _testModel1.registerWitRouter();
+        _testModel2 = new TestModel('m2', _router, _workflowActions);
+        _testModel2.registerWitRouter();
+    });
+
+    it('observeOn throws if router is undefined', () => {
+        expect(() => {
+            return esp.Observable
+                .create(o => { })
+                .observeOn(undefined, 'foo')
+                .observe(o => {});
+        }).toThrow(new Error('router must be defined'));
+    });
+
+    it('observeOn throws if router is null', () => {
+        expect(() => {
+            return esp.Observable
+                .create(o => { })
+                .observeOn(null, 'foo')
+                .observe(o => {});
+        }).toThrow(new Error('router must be defined'));
+    });
+
+    it('observeOn throws if modelid is undefined', () => {
+        expect(() => {
+            return esp.Observable
+                .create(o => { })
+                .observeOn(_router, undefined)
+                .observe(o => {});
+        }).toThrow(new Error('modelId must be a string'));
+    });
+
+    it('observeOn passes onComplete up it\'s dispose chain', () => {
+        _testModel1
+            .getPrices()
+            .observeOn(_router, _testModel1.modelId)
+            .where(p => p.pair === 'EURUSD')
+            .observe(
+                p => {
+                    _workflowActions.push(`priceReceived-${p.pair}-${p.price}`);
+                },
+                () => {
+                    _workflowActions.push('completed');
+                }
+            );
+
+        _testModel1.pushPrice({pair:'EURUSD', price:1});
+        expect(_workflowActions).toEqual(['obsCreate-m1', 'preProcess-m1', 'priceReceived-EURUSD-1', 'postProcess-m1']);
+        _testModel1.priceSubject.onCompleted();
+        expect(_workflowActions).toEqual([
+            'obsCreate-m1',
+            'preProcess-m1', 'priceReceived-EURUSD-1', 'postProcess-m1',
+            'preProcess-m1', 'completed', 'postProcess-m1'
+        ]);
+
+        _workflowActions.length = 0;
+        _testModel1.pushPrice({pair:'EURUSD', price:2});
+        expect(_workflowActions.length).toEqual(0);
+    });
+
+    it('observeOn to the stream on models dispatch loop', () => {
+        _testModel1
+            .getPrices()
+            .observeOn(_router, _testModel1.modelId)
+            .observe(o => {
+                _testModel1.workflowActions.push('observerCalled');
+            });
+        _testModel1.pushPrice({pair:'EURUSD', price:1});
+        expect(_workflowActions).toEqual(['obsCreate-m1', 'preProcess-m1', 'observerCalled', 'postProcess-m1']);
+    });
+
+    it('observeOn and subscribeOn run on correct dispatch loop', () => {
+        _testModel1
+            .getPrices()
+            .subscribeOn(_router, _testModel1.modelId)
+            .observeOn(_router, _testModel2.modelId)
+            .observe(o => {
+               _testModel1.workflowActions.push('observerCalled');
+            });
+        _testModel1.pushPrice({pair:'EURUSD', price:1});
+        expect(_workflowActions).toEqual(['preProcess-m1', 'obsCreate-m1', 'postProcess-m1', 'preProcess-m2', 'observerCalled', 'postProcess-m2']);
+    });
+});

--- a/tests/reactive/subscribeOnTests.js
+++ b/tests/reactive/subscribeOnTests.js
@@ -1,0 +1,84 @@
+// notice_start
+/*
+ * Copyright 2015 Dev Shop Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// notice_end
+
+import esp from '../../src';
+import TestModel from './testModel';
+
+describe('.subscribeOn', () => {
+    var _router;
+    var _testModel1;
+
+    beforeEach(() => {
+        _router = new esp.Router();
+        _testModel1 = new TestModel('m1', _router);
+        _testModel1.registerWitRouter();
+    });
+
+    it('subscribeOn throws if router is undefined', () => {
+        expect(() => {
+            return esp.Observable
+                .create(o => { })
+                .subscribeOn(undefined, 'foo')
+                .observe(o => {});
+        }).toThrow(new Error('router must be defined'));
+    });
+
+    it('subscribeOn throws if router is null', () => {
+        expect(() => {
+            return esp.Observable
+                .create(o => { })
+                .subscribeOn(null, 'foo')
+                .observe(o => {});
+        }).toThrow(new Error('router must be defined'));
+    });
+
+    it('subscribeOn throws if modelid is undefined', () => {
+        expect(() => {
+            return esp.Observable
+                .create(o => { })
+                .subscribeOn(_router, undefined)
+                .observe(o => {});
+        }).toThrow(new Error('modelId must be a string'));
+    });
+
+    it('subscribeOn passes disposable up it\'s dispose chain', () => {
+        let receivedPrices = [];
+        let disposable = _testModel1
+            .getPrices()
+            .subscribeOn(_router, _testModel1.modelId)
+            .where(p => p.pair === 'EURUSD')
+            .observe(p => {
+                receivedPrices.push(`priceReceived-${p.pair}-${p.price}`);
+            });
+        _testModel1.pushPrice({pair:'EURUSD', price:1});
+        expect(receivedPrices).toEqual(['priceReceived-EURUSD-1']);
+        disposable.dispose();
+        _testModel1.pushPrice({pair:'EURUSD', price:2});
+        expect(receivedPrices).toEqual(['priceReceived-EURUSD-1']);
+    });
+
+    it('subscribes to the stream on models dispatch loop', () => {
+        _testModel1
+            .getPrices()
+            .subscribeOn(_router, _testModel1.modelId)
+            .observe(o => {
+                _testModel1.workflowActions.push('observerCalled');
+            });
+        expect(_testModel1.workflowActions).toEqual(['preProcess-m1', 'obsCreate-m1', 'postProcess-m1']);
+    });
+});

--- a/tests/reactive/testModel.js
+++ b/tests/reactive/testModel.js
@@ -1,0 +1,53 @@
+// notice_start
+/*
+ * Copyright 2015 Dev Shop Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// notice_end
+
+import esp from '../../src';
+
+export default class TestModel {
+    constructor(id, router, workflowActions) {
+        this.modelId = id;
+        this.workflowActions = workflowActions || [];
+        this._router = router;
+        this.priceSubject = new esp.Subject();
+    }
+
+    registerWitRouter() {
+        this._router.addModel(this.modelId, this);
+    }
+
+    preProcess() {
+        this.workflowActions.push(`preProcess-${this.modelId}`);
+    }
+
+    getPrices() {
+        return esp.Observable.create(
+            observer => {
+                this.workflowActions.push(`obsCreate-${this.modelId}`);
+                return this.priceSubject.observe(observer);
+            }
+        );
+    }
+
+    postProcess() {
+        this.workflowActions.push(`postProcess-${this.modelId}`);
+    }
+
+    pushPrice(p) {
+        this.priceSubject.onNext(p);
+    }
+}


### PR DESCRIPTION
Adding Observable.subscribeOn and Observable.observeOn. This enables better model to model interactions by allowing models to expose and consume observable streams which will run within a dispatch loop for the model/s in question.

For example a model could expose an esp observable stream such as:
```
    getPrices() {
        return esp.Observable.create(
            observer => {
                // on a dispatch loop for this.modelId
                return this.priceSubject.observe(observer);
            }
        ).subscribeOn(this._router, this.modelId);
    }
```

When a consumer observes this stream the observation factory will be called on the dispatch loop for `this.modelId` in question. 

Similarly, a model consuming an observable stream can do this:
```
        _testModel1
            .getPrices()
            .observeOn(_router, 'myModelId') // i.e. the model where this code resides 
            .where(p => p.pair === 'EURUSD')
            .observe(
                p => {
                       // on a dispatch loop for myModelId
                       // update model state here
                },
                () => {
                      // on a dispatch loop for myModelId
                }
            );
```
