### PR TITLE
#126 - dirty tracking

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,7 +109,7 @@ subscription.dispose();
 
 Output
 
-````
+```
 "Updating view. Username is: anonymous"
 "Updating view. Username is: ben"
 ```

--- a/docs/esp-with-react/index.md
+++ b/docs/esp-with-react/index.md
@@ -1,0 +1,2 @@
+# Using ESP with React
+

--- a/examples/esp-js-react-agile-board/package.json
+++ b/examples/esp-js-react-agile-board/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.4.3",
     "classnames": "^2.2.3",
-    "esp-js": "^1.1.1",
+    "esp-js": "^1.1.3",
     "esp-js-react": "^0.1.0",
     "lodash": "^4.15.0",
     "react": "^15.3.0",

--- a/examples/esp-js-react-agile-board/src/models/modelBase.js
+++ b/examples/esp-js-react-agile-board/src/models/modelBase.js
@@ -1,10 +1,20 @@
+import esp from 'esp-js';
 import _ from 'lodash';
 
+@esp.dirtyTracking()
 export default class ModelBase {
     constructor(modelId, router) {
         this.modelId = modelId;
         this.router = router;
         this._disposables = [];
+        this._isDirty = false;
+    }
+
+    get isDirty() {
+        return this._isDirty;
+    }
+    set isDirty(value) {
+        this._isDirty = value;
     }
 
     observeEvents() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esp-js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Evented State Processor (ESP) adds specific processing workflow around changes to a model's state",
   "keywords": [
     "state processor",

--- a/src/decorators/dirtyTracking.js
+++ b/src/decorators/dirtyTracking.js
@@ -14,12 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- // notice_end
+// notice_end
 
-export {
-    observeEvent,
-    observeModelChangedEvent,
-    DecoratorTypes
-} from './observeEvent';
-export { default as  dirtyTracking } from './dirtyTracking';
-export { default as EspDecoratorMetadata } from './espDecoratorMetadata';
+import { Guard, utils } from "../system";
+import EspDecoratorMetadata from './espDecoratorMetadata';
+
+export default function dirtyTracking(isDirtyPropName) {
+    return function (target, name, descriptor) {
+        // the dirtyTracking decorator is designed to go on a class, thus
+        // 'target' will be the constructor function itself
+        let metadata = EspDecoratorMetadata.getOrCreateOwnMetaData(target);
+        metadata.addDirtyTracking(isDirtyPropName);
+        return descriptor;
+    };
+}

--- a/src/decorators/observeEvent.js
+++ b/src/decorators/observeEvent.js
@@ -54,7 +54,7 @@ export function observeEvent() {
         if(predicate) {
             Guard.isFunction(predicate, 'predicate passed to an observeEvent decorator must be a function');
         }
-        let metadata = EspDecoratorMetadata.getOrCreateOwnMetaData(target);
+        let metadata = EspDecoratorMetadata.getOrCreateOwnMetaData(target.constructor);
         metadata.addEvent(
             name,
             eventName,
@@ -68,7 +68,7 @@ export function observeEvent() {
 
 export function observeModelChangedEvent(modelId) {
     return function (target, name, descriptor) {
-        let metadata = EspDecoratorMetadata.getOrCreateOwnMetaData(target);
+        let metadata = EspDecoratorMetadata.getOrCreateOwnMetaData(target.constructor);
         metadata.addEvent(
             name,
             Const.modelChangedEvent,

--- a/src/index.js
+++ b/src/index.js
@@ -28,12 +28,14 @@
 export { ObservationStage, Router, SingleModelRouter, EventContext, ModelChangedEvent } from './router';
 export { CompositeDisposable, DictionaryDisposable, DisposableBase, DisposableWrapper } from './system/disposables';
 export { observeEvent, observeModelChangedEvent } from './decorators/observeEvent';
+export { default as dirtyTracking } from './decorators/dirtyTracking';
 export { logging as logging } from './system';
 export { Observable, RouterObservable, Subject, RouterSubject } from './reactive';
 
 import { ObservationStage, Router, SingleModelRouter, EventContext, ModelChangedEvent } from './router';
 import { CompositeDisposable, DictionaryDisposable, DisposableBase, DisposableWrapper } from './system/disposables';
 import { observeEvent, observeModelChangedEvent } from './decorators/observeEvent';
+import { default as dirtyTracking } from './decorators/dirtyTracking';
 import { logging as logging } from './system';
 import { Observable, RouterObservable, Subject, RouterSubject  } from './reactive';
 
@@ -45,6 +47,7 @@ export default {
     ModelChangedEvent,
     observeEvent,
     observeModelChangedEvent,
+    dirtyTracking,
     logging,
     EventContext,
     CompositeDisposable,

--- a/src/router/ModelRecord.js
+++ b/src/router/ModelRecord.js
@@ -26,6 +26,7 @@ export default class ModelRecord {
         this._eventQueue = [];
         this._hasChanges = false;
         this._wasRemoved = false;
+        this._postModelDispatchActions = [];
         this._runPreEventProcessor = this._createEventProcessor("preEventProcessor", 'preProcess', options ? options.preEventProcessor : undefined);
         this._runPostEventProcessor = this._createEventProcessor("postEventProcessor", 'postProcess', options ? options.postEventProcessor : undefined);
     }
@@ -55,6 +56,15 @@ export default class ModelRecord {
     }
     get runPostEventProcessor() {
         return this._runPostEventProcessor;
+    }
+    addPostModelDispatchAction(action) {
+        this._postModelDispatchActions.push(action);
+    }
+    runPostModelDispatchActions() {
+        for(let i =0; i < this._postModelDispatchActions.length; i++) {
+            this._postModelDispatchActions[i]();
+        }
+        this._postModelDispatchActions.length = 0;
     }
     _createEventProcessor(name, modelProcessMethod, externalProcessor) {
         var externalProcessor1 = () => { /*noop */ };

--- a/tests/indexTests.js
+++ b/tests/indexTests.js
@@ -15,6 +15,7 @@ import {
     RouterSubject,
     observeEvent,
     observeModelChangedEvent,
+    dirtyTracking,
     model,
     logging,
     DisposableWrapper
@@ -94,6 +95,11 @@ describe('index exports', () => {
     it('should export ModelChangedEvent', () => {
         expect(esp.ModelChangedEvent).toBeDefined();
         expect(ModelChangedEvent).toBeDefined();
+    });
+
+    it('should export dirtyTracking', () => {
+        expect(esp.dirtyTracking).toBeDefined();
+        expect(dirtyTracking).toBeDefined();
     });
 
     it('should export logging', () => {

--- a/tests/router/router.dirtyTrackingTests.js
+++ b/tests/router/router.dirtyTrackingTests.js
@@ -1,0 +1,204 @@
+// notice_start
+/*
+ * Copyright 2015 Dev Shop Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// notice_end
+
+import esp from '../../src';
+
+describe('Router', () => {
+
+    @esp.dirtyTracking()
+    class Entity {
+        constructor(modelId, router) {
+            this.modelId = modelId;
+            this._router = router;
+            this.events = [];
+            this.subEntity = new SubEntity(modelId, router);
+            this.subEntityWithExistingIsDirtyProp = new SubEntityWithExistingGetSetIsDirtyProp(modelId, router);
+        }
+
+        observeEvents() {
+            this._router.addModel(this.modelId, this);
+            this._router.observeEventsOn(this.modelId, this);
+            this.subEntity.observeEvents();
+            this.subEntityWithExistingIsDirtyProp.observeEvents();
+        }
+
+        @esp.observeEvent('anEvent')
+        _onAnEvent(e, c, m) {
+            this.events.push(e);
+        }
+    }
+
+    @esp.dirtyTracking('customIsDirtyProperty')
+    class SubEntity {
+        constructor(modelId, router) {
+            this.modelId = modelId;
+            this._router = router;
+            this.events = [];
+        }
+
+        observeEvents() {
+            this._router.observeEventsOn(this.modelId, this);
+        }
+
+        @esp.observeEvent('aSubEvent')
+        _onASubEvent(e, c, m) {
+            this.events.push(e);
+        }
+    }
+
+    @esp.dirtyTracking()
+    class SubEntityWithExistingGetSetIsDirtyProp {
+        constructor(modelId, router) {
+            this.modelId = modelId;
+            this._router = router;
+            this.events = [];
+            this._isDirty = false;
+        }
+
+        get isDirty() {
+            return this._isDirty;
+        }
+
+        set isDirty(value) {
+            this._isDirty = value;
+        }
+
+        observeEvents() {
+            this._router.observeEventsOn(this.modelId, this);
+        }
+
+        @esp.observeEvent('aSubEvent2')
+        _onASubEvent(e, c, m) {
+            this.events.push(e);
+        }
+    }
+
+    @esp.dirtyTracking()
+    class BaseEntity {
+
+    }
+
+    class DerivedEntity extends BaseEntity {
+        constructor(modelId, router) {
+            super();
+            this.modelId = modelId;
+            this._router = router;
+            this.events = [];
+        }
+
+        observeEvents() {
+            this._router.addModel(this.modelId, this);
+            this._router.observeEventsOn(this.modelId, this);
+        }
+
+        @esp.observeEvent('aDerivedEntityEvent')
+        _onDerivedEntityEvent(e, c, m) {
+            this.events.push(e);
+        }
+    }
+
+    describe('Dirty Tracking', function () {
+
+        var _router,
+            _entity,
+            _entityWasDirty,
+            _subEntityWasDirty,
+            _subEntityWithExistingGetSetIsDirtyPropWasDirty,
+            _derivedEntity,
+            _derivedEntityWasDirty;
+
+        beforeEach(() => {
+            _router = new esp.Router();
+            _entity = new Entity('entityId', _router);
+            _entity.observeEvents();
+            _derivedEntity = new DerivedEntity('derivedEntityId', _router);
+            _derivedEntity.observeEvents();
+            _entityWasDirty = false;
+            _subEntityWasDirty = false;
+            _subEntityWithExistingGetSetIsDirtyPropWasDirty = false;
+            _derivedEntityWasDirty = false;
+            _router.getModelObservable('entityId').subscribe(model => {
+                _entityWasDirty = model.isDirty || false;
+                _subEntityWasDirty = model.subEntity.customIsDirtyProperty || false;
+                _subEntityWithExistingGetSetIsDirtyPropWasDirty = model.subEntityWithExistingIsDirtyProp.isDirty;
+            });
+            _router.getModelObservable('derivedEntityId').subscribe(model => {
+                _derivedEntityWasDirty = model.isDirty;
+            });
+        });
+
+        it('should flag entity as dirty if it receives an event', () => {
+            _router.publishEvent('entityId', 'anEvent', {});
+            expect(_entityWasDirty).toEqual(true);
+        });
+
+        it('should reset flag after model dispatch', () => {
+            _router.publishEvent('entityId', 'anEvent', {});
+            expect(_entity.isDirty).toEqual(false);
+        });
+
+        it('should flag entities each time', () => {
+            _router.publishEvent('entityId', 'anEvent', {});
+            expect(_entityWasDirty).toEqual(true);
+            expect(_entity.isDirty).toEqual(false);
+            _entityWasDirty = false;
+
+            _router.publishEvent('entityId', 'anEvent', {});
+            expect(_entityWasDirty).toEqual(true);
+            expect(_entity.isDirty).toEqual(false);
+            _entityWasDirty = false;
+        });
+
+        it('should flag a sub entity as dirty if it receives an event', () => {
+            _router.publishEvent('entityId', 'aSubEvent', {});
+            expect(_subEntityWasDirty).toEqual(true);
+        });
+
+        it('should reset sub entity flag after model dispatch', () => {
+            _router.publishEvent('entityId', 'aSubEvent', {});
+            expect(_entity.subEntity.customIsDirtyProperty).toEqual(false);
+        });
+
+        it('should only flag the entity that was changed', () => {
+            _router.publishEvent('entityId', 'anEvent', {});
+            expect(_entityWasDirty).toEqual(true);
+            expect(_subEntityWasDirty).toEqual(false);
+            _entityWasDirty = false;
+
+            _router.publishEvent('entityId', 'aSubEvent', {});
+            expect(_entityWasDirty).toEqual(false);
+            expect(_subEntityWasDirty).toEqual(true);
+            _subEntityWasDirty = false;
+
+            expect(_entity.isDirty).toEqual(false);
+            expect(_entity.subEntity.customIsDirtyProperty).toEqual(false);
+        });
+
+        it('should work with get/set style props', () => {
+            _router.publishEvent('entityId', 'aSubEvent2', {});
+            expect(_subEntityWithExistingGetSetIsDirtyPropWasDirty).toEqual(true);
+            expect(_entity.subEntityWithExistingIsDirtyProp.isDirty).toEqual(false);
+        });
+
+        it('should track dirty when decorator declared on base class', () => {
+            _router.publishEvent('derivedEntityId', 'aDerivedEntityEvent', {});
+            expect(_derivedEntityWasDirty).toEqual(true);
+            expect(_derivedEntity.isDirty).toEqual(false);
+        });
+    });
+});


### PR DESCRIPTION
Adds a `@esp.dirtyTracking()` decorator which can update a `isDirty:boolean` property on an entities which receives an event. `@esp.dirtyTracking()` can optionally take a string prop name to use rather than the default `isDirty`. After a model has been dispatched to observers the flag is reverted to a false state. 