### PR TITLE
Fixes #196 - allows you to add custom metadata to an esp-js-ui component

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bootstrap": "lerna bootstrap",
     "build-dev": "./scripts/build-all.sh dev",
     "trash": "./scripts/trash.sh && lerna run clean && lerna clean && rm -rf ./node_modules",
-    "test": "lerna run test",
+    "test": "lerna run test --stream",
     "update-prerelease-version": "yarn _update-version --cd-version=prerelease",
     "update-premajor-version": "yarn _update-version --cd-version=premajor",
     "_update-version": "lerna publish --skip-git --skip-npm --force-publish '*' --preid=next"

--- a/packages/esp-js-ui/src/ui/components/componentDecorator.ts
+++ b/packages/esp-js-ui/src/ui/components/componentDecorator.ts
@@ -8,7 +8,7 @@ export function getComponentFactoryMetadata(target): ComponentFactoryMetadata {
     throw new Error('No metadata found on component');
 }
 
-export function componentFactory(componentKey: string, shortName: string) {
+export function componentFactory(componentKey: string, shortName: string, customMetadata?: any) {
     Guard.isDefined(componentKey, 'componentKey must be defined');
     return (target) => {
         target.__componentMetadata = new ComponentFactoryMetadata(componentKey, shortName);
@@ -16,7 +16,7 @@ export function componentFactory(componentKey: string, shortName: string) {
 }
 
 export class ComponentFactoryMetadata {
-    constructor(public readonly componentKey: string, public readonly shortName: string) {
+    constructor(public readonly componentKey: string, public readonly shortName: string, public readonly customMetadata?: any) {
         Guard.isString(componentKey, 'componentKey must be defined and be a string');
         Guard.isString(shortName, 'shortName must be defined and be a string');
     }

--- a/packages/esp-js-ui/src/ui/components/componentFactoryBase.ts
+++ b/packages/esp-js-ui/src/ui/components/componentFactoryBase.ts
@@ -13,7 +13,7 @@ export abstract class ComponentFactoryBase extends DisposableBase {
     private _currentComponents: Array<ModelBase>;
     private _metadata: ComponentFactoryMetadata;
 
-    constructor(private _container: Container) {
+    protected constructor(private _container: Container) {
         super();
         this._currentComponents = [];
         this._metadata = getComponentFactoryMetadata(this);
@@ -25,6 +25,10 @@ export abstract class ComponentFactoryBase extends DisposableBase {
 
     public get shortName(): string {
         return this._metadata.shortName;
+    }
+
+    public get customMetadata(): any {
+        return this._metadata.customMetadata;
     }
 
     protected abstract _createComponent(childContainer: Container, state?: any): any;


### PR DESCRIPTION
Adds a custom object (`{addToWorkspace: true` in the below) to component factories: 
```
@componentFactory('tradingModule_cashTileComponentFactory', 'Cash Tile', {addToWorkspace: true})
export class CashTileComponentFactory extends ComponentFactoryBase {

}
```