### PR TITLE
Load layout after register view factory

### DIFF
--- a/packages/esp-js-ui/src/ui/dependencyInjection/systemContainerConfiguration.ts
+++ b/packages/esp-js-ui/src/ui/dependencyInjection/systemContainerConfiguration.ts
@@ -39,7 +39,8 @@ export class SystemContainerConfiguration {
             .inject(
                 EspDiConsts.owningContainer,
                 SystemContainerConst.views_registry_model,
-                SystemContainerConst.state_service
+                SystemContainerConst.state_service,
+                SystemContainerConst.router
             )
             .singleton();
 

--- a/packages/esp-js-ui/src/ui/modules/moduleLoader.ts
+++ b/packages/esp-js-ui/src/ui/modules/moduleLoader.ts
@@ -7,16 +7,27 @@ import {ModuleLoadResult} from './moduleLoadResult';
 import {SingleModuleLoader} from './singleModuleLoader';
 import {ModuleConstructor} from './module';
 import {EspModuleDecoratorUtils} from './moduleDecorator';
+import {Router} from 'esp-js';
+import {IdFactory} from '../idFactory';
 
 const _log = Logger.create('ModuleLoader');
 
 export class ModuleLoader {
     private _moduleLoaders: Array<SingleModuleLoader> = [];
+    private _modalLoaderModelId = IdFactory.createId('module-loader');
 
     constructor(
         private _container: Container,
         private _viewRegistryModel: ViewRegistryModel,
-        private _stateService:StateService) {
+        private _stateService:StateService,
+        private _router: Router
+    ) {
+        // This is somewhat of a hack to avoid a race condition whereby modules that load very quickly don't allow the view registry model to process the new view factories before the modules loadLayout is called.
+        // Effectively loadLayout is called right away and it can't find any of the 'enqueued to be registered' view factories.
+        // The below 'ghost model' is used to pop the load layout call onto the back of the dispatch loop which will allow the router to train all other models and thus populate the view factories.
+        // The proper fix for this is to make the ModuleLoader a true esp model, however I don't want to do that in the 2.0 code base as it's using the older version of rx.
+        // I think this is a likely refactor for esp 4.
+        this._router.addModel(this._modalLoaderModelId, {});
     }
 
     /**
@@ -65,19 +76,21 @@ export class ModuleLoader {
     public loadLayout(layoutMode: string, moduleKey: string): void;
     public loadLayout(layoutMode: string): void;
     public loadLayout(...args: any[]): void {
-        const layoutMode = args[0];
-        const moduleKey = args.length === 2 ? args[1] : null;
-        if (moduleKey) {
-            const moduleLoader = this._findModuleLoader(moduleKey);
-            _log.debug(`Loading layout for single module ${moduleLoader.moduleMetadata.moduleKey} with name ${moduleLoader.moduleMetadata.moduleName}`);
-            moduleLoader.loadModuleLayout(layoutMode);
-        } else {
-            _log.debug(`Loading layout ${layoutMode} for all modules`);
-            this._moduleLoaders.forEach(moduleLoader => {
-                _log.debug(`Loading layout for ${moduleLoader.moduleMetadata.moduleKey} with name ${moduleLoader.moduleMetadata.moduleName}`);
+        this._router.runAction(this._modalLoaderModelId, () => {
+            const layoutMode = args[0];
+            const moduleKey = args.length === 2 ? args[1] : null;
+            if (moduleKey) {
+                const moduleLoader = this._findModuleLoader(moduleKey);
+                _log.debug(`Loading layout for single module ${moduleLoader.moduleMetadata.moduleKey} with name ${moduleLoader.moduleMetadata.moduleName}`);
                 moduleLoader.loadModuleLayout(layoutMode);
-            });
-        }
+            } else {
+                _log.debug(`Loading layout ${layoutMode} for all modules`);
+                this._moduleLoaders.forEach(moduleLoader => {
+                    _log.debug(`Loading layout for ${moduleLoader.moduleMetadata.moduleKey} with name ${moduleLoader.moduleMetadata.moduleName}`);
+                    moduleLoader.loadModuleLayout(layoutMode);
+                });
+            }
+        });
     }
 
     private _createModuleLoader(moduleConstructor: ModuleConstructor): SingleModuleLoader {

--- a/packages/esp-js-ui/src/ui/viewFactory/viewRegistryModel.ts
+++ b/packages/esp-js-ui/src/ui/viewFactory/viewRegistryModel.ts
@@ -81,7 +81,7 @@ export class ViewRegistryModel extends ModelBase {
         this._createView(event.viewFactoryKey);
     }
 
-    public hasViewFacotory(viewFactoryKey: string) {
+    public hasViewFactory(viewFactoryKey: string) {
         return this._viewFactoriesEntries.hasOwnProperty(viewFactoryKey);
     }
 


### PR DESCRIPTION
**Issue**: When `singleModuleLoader.ts` `load()`, it `.registerViewFactories(viewRegistryModel)`. However this action is run on a dispatchLoop with "esp-view-registry" modelId. which queues the event after all the "shell-model" events. When the `moduleBase` `loadLayout`, the viewRegistryModel has not yet registered the view, hence the creation of the view will be skipped.
**Solution**: run `loadLayout` for module on a dispatchLoop so it gets queued after the events for "esp-view-registry".