### PR TITLE
Adding support for React.context via the existing <RouterProvider />

### DIFF
--- a/packages/esp-js-react/src/index.ts
+++ b/packages/esp-js-react/src/index.ts
@@ -20,7 +20,7 @@
 // import for side effects
 import './polimer/polimerExtentsions';
 
-export {RouterProvider} from './routerProvider';
+export {RouterProvider, HooksRouterProvider, RouterContext} from './routerProvider';
 export {SmartComponent} from './smartComponent';
 export {ViewBinder} from './viewBinder';
 export {viewBinding, DEFAULT_VIEW_KEY} from './viewBindingDecorator';

--- a/packages/esp-js-react/src/routerProvider.tsx
+++ b/packages/esp-js-react/src/routerProvider.tsx
@@ -24,6 +24,10 @@ export interface RouterProviderProps {
     router: Router;
 }
 
+export const RouterContext = React.createContext<Router>(null);
+
+export const HooksRouterProvider = RouterContext.Provider;
+
 export class RouterProvider extends React.Component<RouterProviderProps, any> {
     static childContextTypes = {
         router: PropTypes.instanceOf(Router).isRequired
@@ -34,6 +38,6 @@ export class RouterProvider extends React.Component<RouterProviderProps, any> {
         };
     }
     render() {
-        return React.Children.only(this.props.children);
+        return (<HooksRouterProvider value={this.props.router}>{this.props.children}</HooksRouterProvider>);
     }
 }

--- a/packages/esp-js-react/tests/indexTests.ts
+++ b/packages/esp-js-react/tests/indexTests.ts
@@ -19,6 +19,7 @@
 import * as espReact from '../src/index';
 import {
     RouterProvider,
+    RouterContext,
     SmartComponent,
     ViewBinder,
     viewBinding,
@@ -31,6 +32,11 @@ describe('index exports', () => {
     it('should export RouterProvider', () => {
         expect(espReact.RouterProvider).toBeDefined();
         expect(RouterProvider).toBeDefined();
+    });
+
+    it('should export RouterContext', () => {
+        expect(espReact.RouterContext).toBeDefined();
+        expect(RouterContext).toBeDefined();
     });
 
     it('should export SmartComponent', () => {


### PR DESCRIPTION
if you're using `<RouterProvider router={theRouter} />`, that will now additionally add the router to a context available via the newer React context API.

### Example

At high level in your app, you prob already have a component providing the router like this:

```
<RouterProvider router={theRouter}><App /></RouterProvider> 
```

That makes the router available via the legacy React API, but now also the newer API. 

Now within a functional component you can get the router like this:

```
import { Router } from 'esp-js';
import { RouterContext } from 'esp-js-ui';

const ThingComponent = (props) => {
  const router = React.useContext<Router>(RouterContext);
  // use the router
}
```
