### PR TITLE
esp-js-di: adding options to 'container.isRegistered(key, options?)'

### DIFF
--- a/packages/esp-js-di/esp-js-di.d.ts
+++ b/packages/esp-js-di/esp-js-di.d.ts
@@ -21,8 +21,8 @@ export class Container {
     registerFactory<T>(name: String, factory:(context: Container, ...additionalDependencies: any[]) => T): RegistrationModifier;
     resolve<T>(name: String, ...additionalDependencies): T;
     resolveGroup<T>(groupName: String): Array<T>;
-    isRegistered(name: string) : boolean;
-    isGroupRegistered(groupName: string) : boolean;
+    isRegistered(name: string, options?: IsRegisteredQueryOptions) : boolean;
+    isGroupRegistered(groupName: string, options?: IsRegisteredQueryOptions) : boolean;
     addResolver<T>(name:String, resolver:Resolver<T>);
     on<T extends object = object>(eventType: ContainerEventType, eventHandler: (notification: ContainerNotification<T>) => void);
     off<T extends object = object>(eventType: ContainerEventType, eventHandler: (notification: ContainerNotification<T>) => void);
@@ -38,6 +38,18 @@ export class RegistrationModifier {
     singleton():RegistrationModifier;
     singletonPerContainer():RegistrationModifier;
     inGroup(groupName:String):RegistrationModifier;
+}
+
+/**
+ * An optional param which can modify how an 'isRegistered' or 'isGroupRegistered' search is performed.
+ *
+ * If omitted defaults to { searchContainerChain: true }
+ */
+export interface IsRegisteredQueryOptions {
+    /**
+     * If true (default) will search in the current container, and along it's chain up to the root container.
+     */
+    searchParentContainers: boolean;
 }
 
 /**

--- a/packages/esp-js-di/src/container.js
+++ b/packages/esp-js-di/src/container.js
@@ -21,6 +21,7 @@ import RegistrationModifier from './registrationModifier';
 import Guard from './guard';
 import EspDiConsts from './espDiConsts';
 import ResolverNames from './resolverNames';
+import {DefaultIsRegisteredQueryOptions} from './isRegisteredQueryOptions';
 
 export default class Container {
     constructor() {
@@ -92,17 +93,21 @@ export default class Container {
         this._instanceCache[name] = instance;
         this._raiseContainerEvent('instanceRegistered', name, instance)
     }
-    isRegistered(name) {
+    isRegistered(name, options = DefaultIsRegisteredQueryOptions) {
         this._throwIfDisposed();
         Guard.isNonEmptyString(name, 'Error calling isRegistered(name). The name argument must be a string and can not be \'\'');
-        var registration = this._registrations[name];
-        return !!registration;
+        const isRegistered = options.searchParentContainers
+            ? !!this._registrations[name]
+            : this._registrations.hasOwnProperty(name);
+        return isRegistered;
     }
-    isGroupRegistered(groupName) {
+    isGroupRegistered(groupName, options = DefaultIsRegisteredQueryOptions) {
         this._throwIfDisposed();
         Guard.isNonEmptyString(groupName, 'Error calling isGroupRegistered(groupName). The groupName argument must be a string and can not be \'\'');
-        var registration = this._registrationGroups[groupName];
-        return !!registration;
+        const isGroupRegistered = options.searchParentContainers
+            ? !!this._registrationGroups[groupName]
+            : this._registrationGroups.hasOwnProperty(groupName);
+        return isGroupRegistered;
     }
     resolve(name, ...additionalDependencies) {
         this._throwIfDisposed();

--- a/packages/esp-js-di/src/isRegisteredQueryOptions.js
+++ b/packages/esp-js-di/src/isRegisteredQueryOptions.js
@@ -1,0 +1,3 @@
+export const DefaultIsRegisteredQueryOptions = {
+    searchParentContainers: true
+}

--- a/packages/esp-js-di/tests/containerTests.js
+++ b/packages/esp-js-di/tests/containerTests.js
@@ -598,6 +598,118 @@ describe('Container', () =>  {
             let isRegistered = container.isRegistered('b');
             expect(isRegistered).toBe(false);
         });
+
+        describe('isRegistered(key, IsRegisteredQueryOptions)', () => {
+            let childContainer;
+
+            describe('when item is registered in parent', () => {
+                beforeEach(() => {
+                    container.register('a', {});
+                    childContainer = container.createChildContainer();
+                });
+
+                it('Should return true by default', () => {
+                    let isRegistered = childContainer.isRegistered('a');
+                    expect(isRegistered).toBe(true);
+                });
+
+                it('Should return true when searchParentContainers is true', () => {
+                    let isRegistered = childContainer.isRegistered('a', { searchParentContainers: true });
+                    expect(isRegistered).toBe(true);
+                });
+
+                it('Should return false when searchParentContainers is false', () => {
+                    let isRegistered = childContainer.isRegistered('a', { searchParentContainers: false });
+                    expect(isRegistered).toBe(false);
+                });
+            });
+
+            describe('when item is registered in child', () => {
+                beforeEach(() => {
+                    childContainer = container.createChildContainer();
+                    childContainer.register('a', {});
+                });
+
+                it('Should return true by default', () => {
+                    let isRegistered = childContainer.isRegistered('a');
+                    expect(isRegistered).toBe(true);
+                });
+
+                it('Should return true when searchParentContainers is true', () => {
+                    let isRegistered = childContainer.isRegistered('a', { searchParentContainers: true });
+                    expect(isRegistered).toBe(true);
+                });
+
+                it('Should return true when searchParentContainers is false', () => {
+                    let isRegistered = childContainer.isRegistered('a', { searchParentContainers: false });
+                    expect(isRegistered).toBe(true);
+                });
+            });
+        });
+    })
+
+    describe('isGroupRegistered', () => {
+
+        it('Should return true when a key is registered in group', () => {
+            container.register('a', {}).inGroup('group-1');
+            container.register('b', {}).inGroup('group-1');
+            let isGroupRegistered = container.isGroupRegistered('group-1');
+            expect(isGroupRegistered).toBe(true);
+        });
+
+        it('Should return false when a key is not registered in group', () => {
+            container.register('a', {}).singleton();
+            let isGroupRegistered = container.isGroupRegistered('b');
+            expect(isGroupRegistered).toBe(false);
+        });
+
+        describe('isGroupRegistered(key, IsRegisteredQueryOptions)', () => {
+            let childContainer;
+
+            describe('when item is registered in parent', () => {
+                beforeEach(() => {
+                    container.register('a', {}).inGroup('group-1');
+                    childContainer = container.createChildContainer();
+                });
+
+                it('Should return true by default', () => {
+                    let isGroupRegistered = childContainer.isGroupRegistered('group-1');
+                    expect(isGroupRegistered).toBe(true);
+                });
+
+                it('Should return true when searchParentContainers is true', () => {
+                    let isGroupRegistered = childContainer.isGroupRegistered('group-1', { searchParentContainers: true });
+                    expect(isGroupRegistered).toBe(true);
+                });
+
+                it('Should return false when searchParentContainers is false', () => {
+                    let isGroupRegistered = childContainer.isGroupRegistered('group-1', { searchParentContainers: false });
+                    expect(isGroupRegistered).toBe(false);
+                });
+            });
+
+            describe('when item is registered in child', () => {
+                beforeEach(() => {
+                    childContainer = container.createChildContainer();
+                    childContainer.register('a', {}).inGroup('group-1');
+                });
+
+                it('Should return true by default', () => {
+                    let isGroupRegistered = childContainer.isGroupRegistered('group-1');
+                    expect(isGroupRegistered).toBe(true);
+                });
+
+                it('Should return true when searchParentContainers is true', () => {
+                    let isGroupRegistered = childContainer.isGroupRegistered('group-1', { searchParentContainers: true });
+                    expect(isGroupRegistered).toBe(true);
+                });
+
+                it('Should return true when searchParentContainers is false', () => {
+                    let isGroupRegistered = childContainer.isGroupRegistered('group-1', { searchParentContainers: false });
+                    expect(isGroupRegistered).toBe(true);
+                });
+            });
+        });
     })
 
     describe('container events', () => {


### PR DESCRIPTION
Adding an options param to container.isRegistered(key, options?) which allows the caller to state if they want the search to include the parent container. By default this is true matching existing behaviour.

```
let container = new Container();
container.register('a', SomeClass);

let childContainer = container.createChildContainer();

childContainer.isRegistered('a'); // true: existing behavaiour 
childContainer.isRegistered('a', { searchParentContainers: true }); // true: matches existing behavaiour 
childContainer.isRegistered('a', { searchParentContainers: false }); // false: registereation only in parent container 
```