### PR TITLE
Polimer model builder withStateHandlerObject and withEventStreams removal

### DIFF
--- a/packages/esp-js-polimer/src/eventTransformations.ts
+++ b/packages/esp-js-polimer/src/eventTransformations.ts
@@ -28,8 +28,6 @@ export interface InputEvent<TModel, TEvent> {
 
 export type InputEventStream<TModel, TEvent> = Observable<InputEvent<TModel, TEvent>>;
 
-export type InputEventStreamFactory<TModel, TEvent = any> = (eventType: string | string[], observationStage?: ObservationStage) => InputEventStream<TModel, TEvent>;
-
 export type OutputEvent<TEvent> = {
     readonly eventType: string;
     /**
@@ -48,5 +46,3 @@ export type OutputEvent<TEvent> = {
 };
 
 export type OutputEventStream<TEvent> = Observable<OutputEvent<TEvent>>;
-
-export type OutputEventStreamFactory<TModel, TInputEvent, TOutputEvent>  = (getEventStreamFor: InputEventStreamFactory<TModel, TInputEvent>) => OutputEventStream<TOutputEvent>;

--- a/packages/esp-js-polimer/src/index.ts
+++ b/packages/esp-js-polimer/src/index.ts
@@ -1,17 +1,15 @@
 // import for side effects
 import './modelBuilder';
 
-export {multipleEvents, PolimerEventHandler, PolimerHandlerMap} from './stateEventHandlers';
+export {PolimerEventHandler} from './stateEventHandlers';
 export {PolimerModel} from './polimerModel';
 export {ImmutableModel} from './immutableModel';
 export {PolimerModelBuilder} from './modelBuilder';
 export {
     InputEvent,
     InputEventStream,
-    OutputEventStreamFactory,
     OutputEvent,
     OutputEventStream,
-    InputEventStreamFactory,
     eventTransformFor
 } from './eventTransformations';
 export {PolimerEvents} from './polimerEvents';

--- a/packages/esp-js-polimer/src/stateEventHandlers.ts
+++ b/packages/esp-js-polimer/src/stateEventHandlers.ts
@@ -1,13 +1,3 @@
 import {EventContext} from 'esp-js';
 
 export type PolimerEventHandler<TState, TEvent, TModel> = (draft: TState, event: TEvent, model: TModel, eventContext: EventContext) => void | TState;
-
-export type PolimerHandlerMap<TState, TModel> = {
-    [index: string]: PolimerEventHandler<TState, any, TModel>
-};
-
-export const MULTIPLE_EVENTS_DELIMITER = '|$|';
-
-export const multipleEvents = (...events: string[]) => {
-    return events.join(MULTIPLE_EVENTS_DELIMITER);
-};

--- a/packages/esp-js-polimer/tests/eventObservationTests.ts
+++ b/packages/esp-js-polimer/tests/eventObservationTests.ts
@@ -5,37 +5,6 @@ import {defaultTestStateFactory, EventConst} from './testApi/testModel';
 describe('Event Observation', () => {
     let api: PolimerTestApi;
 
-    describe('handler maps', () => {
-        beforeEach(() => {
-            api = PolimerTestApiBuilder.create()
-                .withStateHandlerMap()
-                .build();
-            api.asserts.handlerMapState.captureCurrentState();
-        });
-
-        afterEach(() => {
-            api.asserts.handlerMapState.stateInstanceHasChanged();
-        });
-
-        it('can receives events at normal stage', () => {
-            let testEvent = api.actor.publishEvent(EventConst.event1);
-            api.asserts.handlerMapState
-                .normalEvents()
-                .eventCountIs(1)
-                .callIs(0, EventConst.event1, testEvent, ObservationStage.normal);
-        });
-
-        it('can receives multiple events via same handler', () => {
-            let event3 = api.actor.publishEvent(EventConst.event3);
-            let event4 = api.actor.publishEvent(EventConst.event4);
-            api.asserts.handlerMapState
-                .normalEvents()
-                .eventCountIs(2)
-                .callIs(0, EventConst.event3, event3, ObservationStage.normal)
-                .callIs(1, EventConst.event4, event4, ObservationStage.normal);
-        });
-    });
-
     describe('handler objects', () => {
         beforeEach(() => {
             api = PolimerTestApiBuilder.create()
@@ -149,27 +118,20 @@ describe('Event Observation', () => {
     describe('handler compositions', () => {
         beforeEach(() => {
             api = PolimerTestApiBuilder.create()
-                .withStateHandlerMap()
                 .withStateHandlerObject()
                 .withStateHandlerModel()
                 .build();
-            api.asserts.handlerMapState.captureCurrentState();
             api.asserts.handlerObjectState.captureCurrentState();
             api.asserts.handlerModelState.captureCurrentState();
         });
 
         afterEach(() => {
-            api.asserts.handlerMapState.stateInstanceHasChanged();
             api.asserts.handlerObjectState.stateInstanceHasChanged();
             api.asserts.handlerModelState.stateInstanceHasChanged();
         });
 
         it('updates all states that observed the event', () => {
             let testEvent = api.actor.publishEvent(EventConst.event1);
-            api.asserts.handlerMapState
-                .normalEvents()
-                .eventCountIs(1)
-                .callIs(0, EventConst.event1, testEvent, ObservationStage.normal);
             api.asserts.handlerObjectState
                 .normalEvents()
                 .eventCountIs(1)
@@ -260,53 +222,6 @@ describe('Event Observation', () => {
     });
 
     describe('Dispatch handler signature', () => {
-
-        describe('handler maps', () => {
-            beforeEach(() => {
-                api = PolimerTestApiBuilder.create()
-                    .withStateHandlerMap()
-                    .build();
-                api.asserts.handlerMapState.captureCurrentState();
-            });
-
-            afterEach(() => {
-                api.asserts.handlerMapState.stateInstanceHasChanged();
-            });
-
-            it('only dispatches event once', () => {
-                api.actor.publishEvent(EventConst.event1);
-                api.asserts.handlerMapState
-                    .receivedEventsAll()
-                    .eventCountIs(1);
-            });
-            it('receives the current state', () => {
-                api.actor.publishEvent(EventConst.event1);
-                api.asserts.handlerMapState
-                    .receivedEventsAll()
-                    .stateIs(0, 'handlerMapState');
-            });
-
-            it('receives the given event', () => {
-                const event = api.actor.publishEvent(EventConst.event1);
-                api.asserts.handlerMapState
-                    .receivedEventsAll()
-                    .eventIs(0, event);
-            });
-
-            it('receives the current model', () => {
-                api.actor.publishEvent(EventConst.event1);
-                api.asserts.handlerMapState
-                    .receivedEventsAll()
-                    .ensureModelReceived(0);
-            });
-
-            it('receives the event context', () => {
-                api.actor.publishEvent(EventConst.event1);
-                api.asserts.handlerMapState
-                    .receivedEventsAll()
-                    .ensureEventContextReceived(0);
-            });
-        });
 
         describe('handler objects', () => {
             beforeEach(() => {
@@ -415,7 +330,6 @@ describe('Event Observation', () => {
         beforeEach(() => {
             api = PolimerTestApiBuilder.create()
                 .withStateHandlerModel()
-                .withStateHandlerMap()
                 .withStateHandlerObject()
                 .build();
             api.asserts.handlerModelState.captureCurrentState();
@@ -425,7 +339,6 @@ describe('Event Observation', () => {
             api.actor.publishEventWhichFiltersAtPreviewStage(EventConst.event5);
             api.asserts.handlerModelState.receivedEventsAll().eventCountIs(0);
             api.asserts.handlerObjectState.receivedEventsAll().eventCountIs(0);
-            api.asserts.handlerMapState.receivedEventsAll().eventCountIs(1); // maps don't support filtering, no decorator support
         });
     });
 
@@ -433,18 +346,15 @@ describe('Event Observation', () => {
         beforeEach(() => {
             api = PolimerTestApiBuilder.create()
                 .withStateHandlerModel()
-                .withStateHandlerMap()
                 .withStateHandlerObject()
                 .build();
             api.asserts.handlerModelState.captureCurrentState();
-            api.asserts.handlerMapState.captureCurrentState();
             api.asserts.handlerObjectState.captureCurrentState();
         });
 
         it('mutative state changes result in a new state object', () => {
             api.actor.publishEvent(EventConst.event1);
             api.asserts.handlerModelState.stateInstanceHasChanged();
-            api.asserts.handlerMapState.stateInstanceHasChanged();
             api.asserts.handlerObjectState.stateInstanceHasChanged();
         });
 
@@ -452,7 +362,6 @@ describe('Event Observation', () => {
             const nextState = defaultTestStateFactory('replacementState');
             api.actor.publishEvent(EventConst.event5, {replacementState: nextState});
             api.asserts.handlerObjectState.stateInstanceHasChanged(nextState);
-            api.asserts.handlerMapState.stateInstanceHasChanged(nextState);
             api.asserts.handlerModelState.stateInstanceHasChanged(); // doesn't support swapping of state, doesn't use immer
         });
     });

--- a/packages/esp-js-polimer/tests/testApi/stateHandlers.ts
+++ b/packages/esp-js-polimer/tests/testApi/stateHandlers.ts
@@ -1,4 +1,4 @@
-import {multipleEvents, PolimerHandlerMap, PolimerModel} from '../../src/';
+import {PolimerModel} from '../../src/';
 import {defaultOOModelTestStateFactory, EventConst, OOModelTestState, ReceivedEvent, TestEvent, TestState, TestImmutableModel} from './testModel';
 import {EventContext, DefaultEventContext, ObservationStage, observeEvent, PolimerEventPredicate, ObserveEventPredicate, DisposableBase, Router} from 'esp-js';
 
@@ -40,7 +40,6 @@ function isTestState(state: any): state is TestState {
 function isImmutableTestModel(model: any): model is TestImmutableModel {
     let testModel = <TestImmutableModel>model;
     return testModel && (
-        testModel.handlerMapState !== undefined &&
         testModel.handlerModelState !== undefined &&
         testModel.handlerObjectState !== undefined
     );
@@ -64,30 +63,6 @@ const observeEventPredicate: ObserveEventPredicate = (model?: any, event?: TestE
         eventContext.commit();
     }
     return !event.shouldFilter;
-};
-
-export const TestStateHandlerMap: PolimerHandlerMap<TestState, TestImmutableModel> = {
-    [EventConst.event1]: (draft: TestState, ev: TestEvent, model: TestImmutableModel, eventContext: EventContext) => {
-        processEvent(draft, ev, model, eventContext);
-    },
-    [EventConst.event2]: (draft: TestState, ev: TestEvent, model: TestImmutableModel, eventContext: EventContext) => {
-        processEvent(draft, ev, model, eventContext);
-    },
-    [multipleEvents(EventConst.event3, EventConst.event4)]: (draft: TestState, ev: TestEvent, model: TestImmutableModel, eventContext: EventContext) => {
-        processEvent(draft, ev, model, eventContext);
-    },
-    [EventConst.event5]: (draft: TestState, ev: TestEvent, model: TestImmutableModel, eventContext: EventContext) => {
-        if (ev.replacementState) {
-            return ev.replacementState;
-        }
-        processEvent(draft, ev, model, eventContext);
-    },
-    [EventConst.event7]: (draft: TestState, ev: TestEvent, model: TestImmutableModel, eventContext: EventContext) => {
-        processEvent(draft, ev, model, eventContext);
-    },
-    [EventConst.event8]: (draft: TestState, ev: TestEvent, model: TestImmutableModel, eventContext: EventContext) => {
-        processEvent(draft, ev, model, eventContext);
-    },
 };
 
 export class TestStateObjectHandler {
@@ -155,7 +130,7 @@ export class TestStateHandlerModel extends DisposableBase {
             ...this._currentState,
             preProcessInvokeCount
         };
-    };
+    }
 
     public postProcess() {
         let postProcessInvokeCount = this._currentState.postProcessInvokeCount + 1;

--- a/packages/esp-js-polimer/tests/testApi/testModel.ts
+++ b/packages/esp-js-polimer/tests/testApi/testModel.ts
@@ -56,7 +56,6 @@ export interface OOModelTestState extends TestState {
 }
 
 export interface TestImmutableModel extends ImmutableModel {
-    handlerMapState: TestState;
     handlerObjectState: TestState;
     handlerModelState: OOModelTestState;
 }
@@ -83,7 +82,6 @@ export const defaultOOModelTestStateFactory = (stateName: string) => {
 export const defaultModelFactory: (modelId: string) => TestImmutableModel = (modelId: string) => {
     return {
         modelId: modelId,
-        handlerMapState: defaultTestStateFactory('handlerMapState'),
         handlerObjectState: defaultTestStateFactory('handlerObjectState'),
         handlerModelState: defaultOOModelTestStateFactory('handlerObjectState'),
     };


### PR DESCRIPTION
This PR removes some deprecated polimer APIs:

The first enabled passing a map to the model builder to wire up state handlers on a map. 
Map keys were event names. 
Map keys are much less flexable than decorators, and additionally you can't inject any dependencies into a map, you had to wrap it in another function which is messey. 
The existing API `modeBuilder.withStateHandlerObject` can be used instead. 

```
aPolimerModelBuilder.withStateHandlerMap('handlerMapState', SomeMapObject); // removed
aPolimerModelBuilder.withEventStreams(eventStreamFactory); // removed
```

The second API was for event transformations (for async actions / side effects), these run after state handlers.
The API allowed a factory to be passed to the builder. 
That factory would later be invoked to wire up the event transorms. 
This pattern is also less flexable than using class with decorators (for the same reasons mentioned above).
The existing API `withEventStreamsOn` can be used instead. 

```
aPolimerModelBuilder.withStateHandlerMap('handlerMapState', SomeMapObject); // removed
aPolimerModelBuilder.withEventStreams(eventStreamFactory); // removed
```

