### PR TITLE
Router.broadcast Optimisation

### DIFF
--- a/packages/esp-js-polimer/tests/eventObservationTests.ts
+++ b/packages/esp-js-polimer/tests/eventObservationTests.ts
@@ -272,6 +272,13 @@ describe('Event Observation', () => {
                     .receivedEventsAll()
                     .ensureEventContextReceived(0);
             });
+
+            it('receives broadcast events', () => {
+                const event = api.actor.broadcastEvent(EventConst.event1);
+                api.asserts.handlerObjectState
+                    .receivedEventsAll()
+                    .eventIs(0, event);
+            });
         });
 
         describe('handler models', () => {
@@ -322,6 +329,13 @@ describe('Event Observation', () => {
                 api.asserts.handlerModelState
                     .receivedEventsAll()
                     .ensureEventContextReceived(0);
+            });
+
+            it('receives broadcast events', () => {
+                const event = api.actor.broadcastEvent(EventConst.event1);
+                api.asserts.handlerModelState
+                    .receivedEventsAll()
+                    .eventIs(0, event);
             });
         });
     });

--- a/packages/esp-js-polimer/tests/testApi/testApi.ts
+++ b/packages/esp-js-polimer/tests/testApi/testApi.ts
@@ -151,6 +151,11 @@ export class Actor {
         this._router.publishEvent(this._modelId, eventType, event);
         return event;
     }
+    public broadcastEvent(eventType: string, event?: TestEvent) {
+        event = event || {};
+        this._router.broadcastEvent(eventType, event);
+        return event;
+    }
     public publishEventWhichFiltersAtPreviewStage<TKey extends keyof TestImmutableModel>(eventType: string) {
         let testEvent = <TestEvent>{ shouldFilter: true, filterAtStage: ObservationStage.preview};
         this._router.publishEvent(this._modelId, eventType, testEvent);

--- a/packages/esp-js/src/router/modelRecord.ts
+++ b/packages/esp-js/src/router/modelRecord.ts
@@ -135,11 +135,15 @@ export class ModelRecord {
         }
         return eventStreamsRegistration.streams;
     }
-    public enqueueEvent(eventType: string, event: any): void {
+    public tryEnqueueEvent(eventType: string, event: any): boolean {
+        if (!this._eventStreams.has(eventType)) {
+            return false;
+        }
         if (!this._eventQueueDirtyEpochMs) {
             this._eventQueueDirtyEpochMs = Date.now();
         }
         this.eventQueue.push({eventType: eventType, event: event});
+        return true;
     }
     public eventQueuePurged() {
         this._eventQueueDirtyEpochMs = null;

--- a/packages/esp-js/tests/router/router.eventProcessorsTests.ts
+++ b/packages/esp-js/tests/router/router.eventProcessorsTests.ts
@@ -160,25 +160,25 @@ describe('Router', () => {
             expect(_model5.eventsProcessed).toEqual(['startEvent']);
         });
 
-        it('calls a models preProcess() function if the model is NOT observing the published event', () => {
+        it('does not call a models preProcess() function if the model is NOT observing the published event', () => {
             _router.publishEvent('modelId5', 'nothingListeningToThisEvent', 'theEventPayload');
-            expect(_model5.preProcessCount).toBe(1);
+            expect(_model5.preProcessCount).toBe(0);
         });
 
-        it('calls a models postProcess() function if the model is NOT observing the published event', () => {
+        it('does not call a models postProcess() function if the model is NOT observing the published event', () => {
             _router.publishEvent('modelId5', 'nothingListeningToThisEvent', 'theEventPayload');
-            expect(_model5.postProcessCount).toBe(1);
+            expect(_model5.postProcessCount).toBe(0);
         });
 
-        it('calls a models pre event processor even if the model is not observing the published event', () => {
+        it('does not call a models pre event processor even if the model is not observing the published event', () => {
             _router.publishEvent('modelId1', 'nothingListeningToThisEvent', 'theEventPayload');
-            const passed = _modelsSentForPreProcessing.length === 1;
+            const passed = _modelsSentForPreProcessing.length === 0;
             expect(passed).toBe(true);
         });
 
-        it('calls a models post event processor even if the model is not observing the published event', () => {
+        it('does not call a models post event processor even if the model is not observing the published event', () => {
             _router.publishEvent('modelId1', 'nothingListeningToThisEvent', 'theEventPayload');
-            const passed = _modelsSentForPostProcessing.length === 1;
+            const passed = _modelsSentForPostProcessing.length === 0;
             expect(passed).toBe(true);
         });
 

--- a/packages/esp-js/tests/router/router.getAllEventsObservableTests.ts
+++ b/packages/esp-js/tests/router/router.getAllEventsObservableTests.ts
@@ -35,6 +35,21 @@ describe('Router', () => {
         _router.addModel('modelId1', _model1);
         _router.addModel('modelId2', _model2);
         _router.addModel('modelId3', _model3);
+
+        // getAllEventsObservable won't yield events if the models are not actually observing them.
+        // Given that, we subscribe the above models to the events used in these tests.
+
+        _router.getEventObservable('modelId1', 'Event1').subscribe();
+        _router.getEventObservable('modelId2', 'Event1').subscribe();
+        _router.getEventObservable('modelId3', 'Event1').subscribe();
+
+        _router.getEventObservable('modelId1', 'Event2').subscribe();
+        _router.getEventObservable('modelId2', 'Event2').subscribe();
+        _router.getEventObservable('modelId3', 'Event2').subscribe();
+
+        _router.getEventObservable('modelId1', 'Event3').subscribe();
+        _router.getEventObservable('modelId2', 'Event3').subscribe();
+        _router.getEventObservable('modelId3', 'Event3').subscribe();
     });
 
     describe('.getAllEventsObservable()', () => {

--- a/packages/esp-js/tests/router/router.getModelObservableTests.ts
+++ b/packages/esp-js/tests/router/router.getModelObservableTests.ts
@@ -35,7 +35,7 @@ describe('Router', () => {
 
         it('throws if arguments incorrect', () => {
             expect(() => {_router.getModelObservable(undefined).subscribe(() => {}); }).toThrow(new Error('The modelId should be a string'));
-            expect(() => {_router.getModelObservable({}).subscribe(() => {}); }).toThrow(new Error('The modelId should be a string'));
+            expect(() => {_router.getModelObservable(<any>{}).subscribe(() => {}); }).toThrow(new Error('The modelId should be a string'));
         });
 
         it('dispatches model once registered', () => {
@@ -152,6 +152,20 @@ describe('Router', () => {
             _router.publishEvent('modelId2', 'StartEvent', 'payload');
             expect(model1UpdateCount).toBe(1);
             expect(model2UpdateCount).toBe(2);
+        });
+
+        it('does not dispatches changes when publishing to a model that is not listening to said event', () => {
+            let model1UpdateCount = 0, model2UpdateCount = 0;
+            _router.getModelObservable('modelId1').subscribe(() => {
+                model1UpdateCount++;
+            });
+            expect(model1UpdateCount).toBe(1);
+            _router.publishEvent('modelId1', 'StartEvent', 'payload');
+            expect(model1UpdateCount).toBe(1);
+            // now observe and publish again
+            _router.getEventObservable('modelId1', 'StartEvent').subscribe(() => { /*noop*/  });
+            _router.publishEvent('modelId1', 'StartEvent', 'payload');
+            expect(model1UpdateCount).toBe(2);
         });
 
         it('should dispatch change to models if event if only one event was processed', () => {


### PR DESCRIPTION
* Updating `PolimerModel` so it uses `router.getEventObservable()`, rather tnan `router.getAllEventsObservable()`. This allows the router to know which events are subscribed to. Previously, when using `getAllEventsObservable()` the router had no knolwedge as this is effictively a fat event pipe rather than an explicit event subscription. 
* Router optimisation so router.broadcastEvent() will now only enqueues the event if the given model is observing to it. This will reduce needless model updates"