### PR TITLE
Fixing a bug where by WeakRef feature detection was only working in the browser

### DIFF
--- a/packages/esp-js/src/system/esNextFeatureDetection.ts
+++ b/packages/esp-js/src/system/esNextFeatureDetection.ts
@@ -1,4 +1,6 @@
-const SupportsWeakRef = !!window.WeakRef;
+import {GlobalState} from './globalState';
+
+const SupportsWeakRef = !!GlobalState.WeakRef;
 
 export interface EsNextFeatureDetectionLike {
     supportsWeakRef: boolean;


### PR DESCRIPTION
The `WeakRef` feature detection wasn't correctly working in NodeJs.

This change makes that detection use ESPs `GlobalState` which is either `window` or `global` depending on which is defined first.