### PR TITLE
v6.3.0 - Metrics and Health Indicator Updates

### DIFF
--- a/packages/esp-js-ui/src/health/aggregateEspDiHealthIndicator.ts
+++ b/packages/esp-js-ui/src/health/aggregateEspDiHealthIndicator.ts
@@ -24,7 +24,7 @@ export class AggregateEspDiHealthIndicator extends AggregateHealthIndicator {
                 this._container.off('instanceCreated', this._instanceRegisteredOrCreated);
             });
             // this class should be used as a singleton, if createGauge is recalled with the same metric name it may blow depending on the implementation used
-            this._aggregateHealthMetric = MetricFactory.createGauge('aggregate_esp_di_health', 'The aggregate health for an application (-1=Unknown,0=Unhealthy,1=Healthy)');
+            this._aggregateHealthMetric = MetricFactory.createGauge('esp_aggregate_health', 'The aggregate health for an application (-1=Unknown,0=Unhealthy,1=Healthy)');
         }
         return wasStarted;
     }

--- a/packages/esp-js-ui/src/health/espAggregateHealthIndicator.ts
+++ b/packages/esp-js-ui/src/health/espAggregateHealthIndicator.ts
@@ -2,15 +2,15 @@ import {GaugeMetric,  MetricFactory} from 'esp-js-metrics';
 import {Logger, Health, HealthUtils, AggregateHealthIndicator, DefaultHealthIndicatorTrigger, HealthIndicatorTrigger} from 'esp-js';
 import {Container, ContainerNotification} from 'esp-js-di';
 
-export class AggregateEspDiHealthIndicator extends AggregateHealthIndicator {
+export class EspAggregateHealthIndicator extends AggregateHealthIndicator {
     private _aggregateHealthMetric: GaugeMetric;
 
     constructor(private _container: Container, healthIndicatorTrigger: HealthIndicatorTrigger = DefaultHealthIndicatorTrigger) {
-        super(Logger.create('AggregateEspDiHealthIndicator'), healthIndicatorTrigger);
+        super(Logger.create('EspAggregateHealthIndicator'), healthIndicatorTrigger);
     }
 
     public get healthIndicatorName() {
-        return 'AggregateEspDiHealthIndicator';
+        return 'EspAggregateHealthIndicator';
     }
 
     public start() {

--- a/packages/esp-js-ui/src/health/index.ts
+++ b/packages/esp-js-ui/src/health/index.ts
@@ -1,2 +1,2 @@
 // Auto-generated 
-export * from './aggregateEspDiHealthIndicator';
+export * from './espAggregateHealthIndicator';

--- a/packages/esp-js-ui/src/ui/dependencyInjection/systemContainerConfiguration.ts
+++ b/packages/esp-js-ui/src/ui/dependencyInjection/systemContainerConfiguration.ts
@@ -14,12 +14,12 @@ export class SystemContainerConfiguration {
     public static configureContainer(rootContainer: Container) {
         _log.verbose('Configuring container with system components');
 
-        if (!rootContainer.isRegistered(SystemContainerConst.aggregate_esp_di_health_indicator)) {
+        if (!rootContainer.isRegistered(SystemContainerConst.esp_aggregate_health_indicator)) {
             // Register a health indicator which monitors container object which themselves are HealthIndicators.
             // This needs to be created now (hence using registerInstance) as it needs to be up and running before types start resolving.
             let aggregateEspDiHealthIndicator = new AggregateEspDiHealthIndicator(rootContainer);
             aggregateEspDiHealthIndicator.start();
-            rootContainer.registerInstance(SystemContainerConst.aggregate_esp_di_health_indicator, aggregateEspDiHealthIndicator);
+            rootContainer.registerInstance(SystemContainerConst.esp_aggregate_health_indicator, aggregateEspDiHealthIndicator);
         }
 
         rootContainer.addResolver(LiteralResolver.resolverName, new LiteralResolver());

--- a/packages/esp-js-ui/src/ui/dependencyInjection/systemContainerConfiguration.ts
+++ b/packages/esp-js-ui/src/ui/dependencyInjection/systemContainerConfiguration.ts
@@ -6,7 +6,7 @@ import {ViewRegistryModel} from '../viewFactory';
 import {LiteralResolver} from './literalResolver';
 import {SchedulerService} from '../../core';
 import {RegionManager} from '../regions/models';
-import {AggregateEspDiHealthIndicator} from '../../health';
+import {EspAggregateHealthIndicator} from '../../health';
 
 const _log = Logger.create('SystemContainerConfiguration');
 
@@ -17,7 +17,7 @@ export class SystemContainerConfiguration {
         if (!rootContainer.isRegistered(SystemContainerConst.esp_aggregate_health_indicator)) {
             // Register a health indicator which monitors container object which themselves are HealthIndicators.
             // This needs to be created now (hence using registerInstance) as it needs to be up and running before types start resolving.
-            let aggregateEspDiHealthIndicator = new AggregateEspDiHealthIndicator(rootContainer);
+            let aggregateEspDiHealthIndicator = new EspAggregateHealthIndicator(rootContainer);
             aggregateEspDiHealthIndicator.start();
             rootContainer.registerInstance(SystemContainerConst.esp_aggregate_health_indicator, aggregateEspDiHealthIndicator);
         }

--- a/packages/esp-js-ui/src/ui/dependencyInjection/systemContainerConst.ts
+++ b/packages/esp-js-ui/src/ui/dependencyInjection/systemContainerConst.ts
@@ -8,5 +8,5 @@ export class SystemContainerConst {
     static get single_module_loader() { return 'single_module_loader'; }
     static get module_provider() { return 'module_provider'; }
     static get module_metadata() { return 'module_metadata'; }
-    static get aggregate_esp_di_health_indicator() { return 'aggregate_esp_di_health_indicator'; }
+    static get esp_aggregate_health_indicator() { return 'esp_aggregate_health_indicator'; }
 }

--- a/packages/esp-js-ui/src/ui/modules/shell.ts
+++ b/packages/esp-js-ui/src/ui/modules/shell.ts
@@ -100,7 +100,7 @@ export abstract class Shell extends DisposableBase implements ModuleProvider {
         this._regionManager = this._container.resolve<RegionManager>(SystemContainerConst.region_manager);
         this._viewRegistryModel = this._container.resolve<ViewRegistryModel>(SystemContainerConst.views_registry_model);
         this._stateService = this._container.resolve<StateService>(SystemContainerConst.state_service);
-        this._aggregateHealthIndicator = this._container.resolve<AggregateHealthIndicator>(SystemContainerConst.aggregate_esp_di_health_indicator);
+        this._aggregateHealthIndicator = this._container.resolve<AggregateHealthIndicator>(SystemContainerConst.esp_aggregate_health_indicator);
         this._registerShellViewFactories();
     }
 

--- a/packages/esp-js-ui/src/ui/modules/shell.ts
+++ b/packages/esp-js-ui/src/ui/modules/shell.ts
@@ -8,7 +8,7 @@ import {IdFactory} from '../idFactory';
 import * as Rx from 'rxjs';
 import {merge, Observable} from 'rxjs';
 import {AggregateModuleLoadResult, ModuleLoadResult, ModuleLoadStage} from './moduleLoadResult';
-import {DisposableBase, Guard, Logger, Router} from 'esp-js';
+import {AggregateHealthIndicator, DisposableBase, Guard, Logger, Router} from 'esp-js';
 import {Module, ModuleConstructor} from './module';
 import {ViewFactoryBase, ViewRegistryModel} from '../viewFactory';
 import {DefaultSingleModuleLoader} from './singleModuleLoader';
@@ -34,6 +34,7 @@ export abstract class Shell extends DisposableBase implements ModuleProvider {
     private _viewRegistryModel: ViewRegistryModel;
     private _router: Router;
     private _stateService: StateService;
+    private _aggregateHealthIndicator: AggregateHealthIndicator;
 
     public constructor(container: Container = new Container()) {
         super();
@@ -96,6 +97,7 @@ export abstract class Shell extends DisposableBase implements ModuleProvider {
         this._regionManager = this._container.resolve<RegionManager>(SystemContainerConst.region_manager);
         this._viewRegistryModel = this._container.resolve<ViewRegistryModel>(SystemContainerConst.views_registry_model);
         this._stateService = this._container.resolve<StateService>(SystemContainerConst.state_service);
+        this._aggregateHealthIndicator = this._container.resolve<AggregateHealthIndicator>(SystemContainerConst.aggregate_esp_di_health_indicator);
         this._registerShellViewFactories();
     }
 
@@ -241,6 +243,7 @@ export abstract class Shell extends DisposableBase implements ModuleProvider {
                 moduleMetadata,
                 moduleConstructor,
             );
+            this._aggregateHealthIndicator.addIndicator(moduleLoader, true);
             this._moduleLoaders.push(moduleLoader);
             let subscription = moduleLoader.loadResults.subscribe(obs);
             moduleLoader.load();

--- a/packages/esp-js-ui/src/ui/modules/shell.ts
+++ b/packages/esp-js-ui/src/ui/modules/shell.ts
@@ -35,7 +35,6 @@ export abstract class Shell extends DisposableBase implements ModuleProvider {
     private _viewRegistryModel: ViewRegistryModel;
     private _router: Router;
     private _stateService: StateService;
-    private _aggregateHealthIndicator: AggregateHealthIndicator;
     private _regionsLoadedCounter = MetricFactory.getOrCreateCounter('esp_regions_loaded', 'Tracks when the shell displays its regions');
     private _modulesLoadedCounter = MetricFactory.getOrCreateCounter('esp_modules_loaded', 'Tracks when all of the shell\'s modules have full loaded');
 
@@ -100,7 +99,6 @@ export abstract class Shell extends DisposableBase implements ModuleProvider {
         this._regionManager = this._container.resolve<RegionManager>(SystemContainerConst.region_manager);
         this._viewRegistryModel = this._container.resolve<ViewRegistryModel>(SystemContainerConst.views_registry_model);
         this._stateService = this._container.resolve<StateService>(SystemContainerConst.state_service);
-        this._aggregateHealthIndicator = this._container.resolve<AggregateHealthIndicator>(SystemContainerConst.esp_aggregate_health_indicator);
         this._registerShellViewFactories();
     }
 
@@ -251,7 +249,6 @@ export abstract class Shell extends DisposableBase implements ModuleProvider {
                 moduleMetadata,
                 moduleConstructor,
             );
-            this._aggregateHealthIndicator.addIndicator(moduleLoader, true);
             this._moduleLoaders.push(moduleLoader);
             let subscription = moduleLoader.loadResults.subscribe(obs);
             moduleLoader.load();

--- a/packages/esp-js-ui/src/ui/modules/singleModuleLoader.ts
+++ b/packages/esp-js-ui/src/ui/modules/singleModuleLoader.ts
@@ -8,6 +8,7 @@ import {Module, ModuleConstructor} from './module';
 import {ModuleMetadata} from './moduleDecorator';
 import {SystemContainerConst} from '../dependencyInjection';
 import {DisposableBase, Health, HealthIndicator, Logger} from 'esp-js';
+import {MetricFactory} from 'esp-js-metrics';
 
 export interface SingleModuleLoader {
     readonly moduleMetadata: ModuleMetadata;
@@ -15,6 +16,8 @@ export interface SingleModuleLoader {
     readonly loadResults: Observable<ModuleLoadResult>;
     readonly hasLoaded: boolean;
 }
+
+const moduleLoadedCounter = MetricFactory.createCounter('esp_module_loaded', 'Counts when an esp module has fully loaded', ['module_key']);
 
 /**
  * Owns load orchestrations for a module.
@@ -221,6 +224,7 @@ export class DefaultSingleModuleLoader extends DisposableBase implements SingleM
                 stage: ModuleLoadStage.Loaded
             });
             this._health = Health.builder(this._healthIndicatorName).isHealthy().build();
+            moduleLoadedCounter.inc({module_key: this._moduleMetadata.moduleKey });
             this._module.onLoadStageChanged(this._lastModuleLoadResult.stage);
             obs.next(this._lastModuleLoadResult);
             obs.complete();

--- a/packages/esp-js-ui/src/ui/modules/singleModuleLoader.ts
+++ b/packages/esp-js-ui/src/ui/modules/singleModuleLoader.ts
@@ -7,7 +7,7 @@ import {ViewRegistryModel} from '../viewFactory';
 import {Module, ModuleConstructor} from './module';
 import {ModuleMetadata} from './moduleDecorator';
 import {SystemContainerConst} from '../dependencyInjection';
-import {DisposableBase, Logger} from 'esp-js';
+import {DisposableBase, Health, HealthIndicator, Logger} from 'esp-js';
 
 export interface SingleModuleLoader {
     readonly moduleMetadata: ModuleMetadata;
@@ -23,13 +23,15 @@ export interface SingleModuleLoader {
  *
  * This loader gets added to the modules container so other areas of the module can get read only access to it.
  */
-export class DefaultSingleModuleLoader extends DisposableBase implements SingleModuleLoader {
+export class DefaultSingleModuleLoader extends DisposableBase implements SingleModuleLoader, HealthIndicator {
     private readonly _preReqsLoader: DefaultPrerequisiteRegister;
     private _log: Logger;
     private _module: Module;
     private _loadStream: ConnectableObservable<ModuleLoadResult>;
     private _lastModuleLoadResult: ModuleLoadResult;
     private _connected = false;
+    private _healthIndicatorName: string;
+    private _health: Health;
 
     public constructor(
         private _container: Container,
@@ -38,9 +40,20 @@ export class DefaultSingleModuleLoader extends DisposableBase implements SingleM
         private _moduleConstructor: ModuleConstructor,
     ) {
         super();
-        this._log = Logger.create(`SingleModuleLoader-${this._moduleMetadata.moduleKey}`);
+        let name = `SingleModuleLoader-${this._moduleMetadata.moduleKey}`;
+        this._log = Logger.create(name);
+        this._healthIndicatorName = name;
+        this._health = Health.builder(name).isUnknown().build();
         this._preReqsLoader = new DefaultPrerequisiteRegister();
         this._loadStream = <ConnectableObservable<ModuleLoadResult>>this._createLoadStream().pipe(multicast(new ReplaySubject<ModuleLoadResult>(1)));
+    }
+
+    public get healthIndicatorName(): string {
+        return this._healthIndicatorName;
+    }
+
+    public health() : Health {
+        return this._health;
     }
 
     public get module(): Module {
@@ -112,7 +125,9 @@ export class DefaultSingleModuleLoader extends DisposableBase implements SingleM
                 this._log.verbose(`Registering prereqs for ${moduleName}`);
                 this.module.registerPrerequisites(this._preReqsLoader);
             } catch (e) {
-                this._log.error(`Failed to create module ${moduleName}`, e);
+                let errorMessage = `Failed to create module ${moduleName}`;
+                this._log.error(errorMessage, e);
+                this._health = Health.builder(this._healthIndicatorName).isUnhealthy().addReason(errorMessage).build();
                 this._lastModuleLoadResult = Object.freeze({
                     type: ModuleChangeType.Error,
                     moduleName,
@@ -180,7 +195,9 @@ export class DefaultSingleModuleLoader extends DisposableBase implements SingleM
                 obs.next(this._lastModuleLoadResult);
                 module.initialise();
             } catch (e) {
-                this._log.error(`Failed to initialise module ${this._moduleMetadata.moduleName}`, e);
+                let errorMessage = `Failed to initialise module ${this._moduleMetadata.moduleName}`;
+                this._log.error(errorMessage, e);
+                this._health = Health.builder(this._healthIndicatorName).isUnhealthy().addReason(errorMessage).build();
                 this._lastModuleLoadResult = Object.freeze({
                     type: ModuleChangeType.Error,
                     moduleName: this._moduleMetadata.moduleName,
@@ -203,6 +220,7 @@ export class DefaultSingleModuleLoader extends DisposableBase implements SingleM
                 hasCompletedLoaded: true,
                 stage: ModuleLoadStage.Loaded
             });
+            this._health = Health.builder(this._healthIndicatorName).isHealthy().build();
             this._module.onLoadStageChanged(this._lastModuleLoadResult.stage);
             obs.next(this._lastModuleLoadResult);
             obs.complete();

--- a/packages/esp-js-ui/tests/health/espAggregateHealthIndicatorTests.ts
+++ b/packages/esp-js-ui/tests/health/espAggregateHealthIndicatorTests.ts
@@ -1,4 +1,4 @@
-import {AggregateEspDiHealthIndicator} from '../../src/health/';
+import {EspAggregateHealthIndicator} from '../../src/health/';
 import {Health, HealthIndicator} from 'esp-js/src';
 import {Container} from 'esp-js-di';
 import {HealthStatus} from 'esp-js';
@@ -18,9 +18,9 @@ class TestHealthIndicator implements HealthIndicator {
     }
 }
 
-describe('AggregateEspDiHealthIndicator', () => {
+describe('EspAggregateHealthIndicator Tests', () => {
     let updates = 0;
-    let aggregateIndicator: AggregateEspDiHealthIndicator = null;
+    let aggregateIndicator: EspAggregateHealthIndicator = null;
     let container: Container;
     let testMetricFactory: TestMetricFactory;
 
@@ -35,7 +35,7 @@ describe('AggregateEspDiHealthIndicator', () => {
         MetricFactoryImplementation.set(testMetricFactory);
         updates = 0;
         container = new Container();
-        aggregateIndicator = new AggregateEspDiHealthIndicator(container);
+        aggregateIndicator = new EspAggregateHealthIndicator(container);
         aggregateIndicator.start();
     });
 
@@ -91,7 +91,7 @@ describe('AggregateEspDiHealthIndicator', () => {
 
     it('health metric changes when health changes', () => {
         let indicator = new TestHealthIndicator('i1');
-        let metric = testMetricFactory.metricsByName.get('aggregate_esp_di_health');
+        let metric = testMetricFactory.metricsByName.get('esp_aggregate_health');
         indicator.setStatus(HealthStatus.Healthy);
         container.registerInstance('indicator1-key', indicator);
 


### PR DESCRIPTION
Added/renamed  metrics:

* `esp_aggregate_health` -> rename of  `aggregate_esp_di_health`.
*  `esp_regions_loaded` -> new metric, tracks when the shell loads regions.
*  `esp_modules_loaded` -> new metric, tracks when the shell loads all modules.

Added HealthIndicator implementatins to module loading infrastructure.
