### PR TITLE
esp-js-di container.resolveGroup now allows for passing '...additionalDependencies

### DIFF
--- a/packages/esp-js-di/esp-js-di.d.ts
+++ b/packages/esp-js-di/esp-js-di.d.ts
@@ -19,8 +19,8 @@ export class Container {
     register(name: String, proto: any):RegistrationModifier;
     registerInstance<T>(name: String, instance: T, isExternallyOwned?): void;
     registerFactory<T>(name: String, factory:(context: Container, ...additionalDependencies: any[]) => T): RegistrationModifier;
-    resolve<T>(name: String, ...additionalDependencies): T;
-    resolveGroup<T>(groupName: String): Array<T>;
+    resolve<T>(name: String, ...additionalDependencies: any[]): T;
+    resolveGroup<T>(groupName: String,  ...additionalDependencies: any[]): Array<T>;
     isRegistered(name: string, options?: IsRegisteredQueryOptions) : boolean;
     isGroupRegistered(groupName: string, options?: IsRegisteredQueryOptions) : boolean;
     addResolver<T>(name:String, resolver:Resolver<T>);

--- a/packages/esp-js-di/src/container.js
+++ b/packages/esp-js-di/src/container.js
@@ -132,7 +132,7 @@ export default class Container {
         }
         return instance;
     }
-    resolveGroup(groupName) {
+    resolveGroup(groupName, ...additionalDependencies) {
         this._throwIfDisposed();
         Guard.isNonEmptyString(groupName, 'Error calling resolveGroup(groupName). The groupName argument must be a string and can not be \'\'');
         var items = [],
@@ -144,7 +144,7 @@ export default class Container {
             throw new Error(error);
         }
         for (let i = 0, len = mapings.length; i < len; i++) {
-            items.push(this.resolve(mapings[i]));
+            items.push(this.resolve(mapings[i], ...additionalDependencies));
         }
         return items;
     }

--- a/packages/esp-js-di/tests/containerTests.js
+++ b/packages/esp-js-di/tests/containerTests.js
@@ -184,6 +184,25 @@ describe('Container', () =>  {
                 expect(A.isPrototypeOf(group1[1].dependencies[0])).toBe(true);
                 expect(group1[0]).not.toBe(group1[1].dependencies[0]);
             });
+
+            it('should pass additional dependencies to object being resolved', () =>  {
+                let A = createObject();
+                let B = createObject();
+                container.register('a', A)
+                    .transient()
+                    .inGroup('myGroup');
+                container.register('b', B)
+                    .transient()
+                    .inGroup('myGroup');
+                // if some registered items are singleton, then this will behave like `resolve`, those objects won't get recreated.
+                let myGroup = container.resolveGroup('myGroup', "Foo", "Bar");
+                expect(myGroup[0].dependencies.length).toEqual(2);
+                expect(myGroup[0].dependencies[0]).toEqual("Foo");
+                expect(myGroup[0].dependencies[1]).toEqual("Bar");
+                expect(myGroup[1].dependencies.length).toEqual(2);
+                expect(myGroup[1].dependencies[0]).toEqual("Foo");
+                expect(myGroup[1].dependencies[1]).toEqual("Bar");
+            });
         });
 
         describe('constructor functions', () =>  {
@@ -940,6 +959,8 @@ describe('Container', () =>  {
 
     function createObject(props) {
         let o = Object.create(Object.prototype, {
+                // The container will call any init() if found.
+                // Not commonly used these days as containers are often used for classes
                 init : {
                     value: function() {
                         this.dependencies = Array.prototype.slice.call(arguments);


### PR DESCRIPTION
Add support to pass an array of items to inject into objects resolved in groups.

```
let A = class A { constructor(public arg1){} }; // has arg1 property
let B = class A { constructor(public arg1){} }; // has arg1 property
container.register('a', A)
    .transient()
    .inGroup('myGroup');
container.register('b', B)
    .transient()
    .inGroup('myGroup');
let myGroup = container.resolveGroup('myGroup', "arg1Foo");
myGroup[0].arg1 === "arg1Foo"; // true
myGroup[1].arg1 === "arg1Foo"; // true
```