### PR TITLE
Adding a 'zero' api to esp-js-metrics HistogramMetric type so known metric labels can be zeroed up front

### DIFF
--- a/packages/esp-js-metrics/src/metrics.ts
+++ b/packages/esp-js-metrics/src/metrics.ts
@@ -64,6 +64,7 @@ export interface HistogramMetric {
     reset(): void;
     labels(...values: string[]): HistogramMetricWithLabels;
     remove(...values: string[]): void;
+    zero(labels?: LabelValues): void;
 }
 
 export interface HistogramMetricWithLabels {

--- a/packages/esp-js-metrics/src/noopMetrics.ts
+++ b/packages/esp-js-metrics/src/noopMetrics.ts
@@ -30,6 +30,7 @@ const NoopMetrics = (new class implements CounterMetric, GaugeMetric, HistogramM
     set(...args:any[]) {}
     startTimer(labels?: LabelValues) { return () => {}; }
     setToCurrentTime(...args:any[])  { }
+    zero(...args:any[]) {}
 });
 
 const NoopMetricsWithLabels = (new class implements CounterMetricWithLabels, GaugeMetricWithLabels, HistogramMetricWithLabels {


### PR DESCRIPTION
This PR adds a `zero()` api to match the API of prom-clients Histogram: https://github.com/siimon/prom-client#zeroing-metrics-with-labels