### PR TITLE
v8.1.0 Performance Tweaks

### DIFF
--- a/packages/esp-js-polimer/src/modelBuilderUpdater.ts
+++ b/packages/esp-js-polimer/src/modelBuilderUpdater.ts
@@ -125,6 +125,10 @@ export class PolimerModelBuilder<TModel extends ImmutableModel, TPersistedModelS
     private _initialModel: TModel;
     private _stateSaveHandler: (model: TModel) => any;
 
+    public static create<TModel extends ImmutableModel, TPersistedModelState = {}> (router: Router) {
+        return new PolimerModelBuilder<TModel, TPersistedModelState>(router);
+    }
+
     constructor(private _router: Router) {
         super();
     }

--- a/packages/esp-js-polimer/src/polimerModel.ts
+++ b/packages/esp-js-polimer/src/polimerModel.ts
@@ -230,7 +230,7 @@ export class PolimerModel<TModel extends ImmutableModel> extends DisposableBase 
 
     @observeEvent(PolimerEvents.disposeModel)
     public dispose() {
-        logger.debug(`Disposing PolimerModel<> ${this._modelId}`);
+        logger.verbose(`Disposing PolimerModel<> ${this._modelId}`);
         this._router.removeModel(this.modelId);
         this._disposablesKeyedOnObjectScannedAtWireup.forEach(d => (d.dispose()));
         super.dispose();

--- a/packages/esp-js/src/router/modelRecord.ts
+++ b/packages/esp-js/src/router/modelRecord.ts
@@ -107,12 +107,14 @@ export class ModelRecord {
     public getOrCreateEventStreamsRegistration(eventType: string, dispatchObservable: Observable<EventEnvelope<any, any>>): EventStreamsRegistration {
         let eventStreamsRegistration = this._eventStreams.get(eventType);
         if (!eventStreamsRegistration) {
-            let eventStream =  dispatchObservable.filter(
+            const modelStream = dispatchObservable.filter(
+                envelope => envelope.modelId === this.modelId
+            ).share(false);
+            const eventStream =  modelStream.filter(
                 envelope =>
                     envelope.dispatchType === DispatchType.Event &&
-                    envelope.modelId === this.modelId &&
                     envelope.eventType === eventType
-            );
+            ).share(false);
             eventStreamsRegistration = {
                 streams: {
                     preview: eventStream


### PR DESCRIPTION
Adds performance improvements to the reactive layer

* Implements a more optimal observer lookup logic, improving the disposal of large models.
* The base reactive object, `Subject`, no longer copies objects to protect against subscriber modifications during dispatch. Instead, it now uses a `Map`, which has more efficient lookups and built-in protection for mid-iteration modifications.
* Optimizations to the event streams for models: Model ID and event type filtering are now shared per event stream, reducing the overall number of filter checks on the underlying reactive stream as events are dispatched.

In addition to the above:
* Minor logging tweaks.
* Added a `create` call, allowing you to use `PolimerModelBuilder` without relying on the monkey-patched functions on `Router`.
